### PR TITLE
docs: add community health and GitHub UX updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @abolsen

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vaner code issues
+    url: https://github.com/Borgels/Vaner/issues
+    about: Report core product bugs in the main Vaner repository.
+  - name: Security disclosures
+    url: https://github.com/Borgels/Vaner/security/policy
+    about: Report vulnerabilities privately through the main repo security policy.

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,0 +1,19 @@
+name: Content request
+description: Request missing docs or improvements to existing docs
+title: "[docs] "
+labels: ["docs"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing or unclear?
+      description: Explain the current gap in docs.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested improvement
+      description: Describe the desired content change.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/typo.yml
+++ b/.github/ISSUE_TEMPLATE/typo.yml
@@ -1,0 +1,19 @@
+name: Typo report
+description: Report typos, broken grammar, or wording issues
+title: "[typo] "
+labels: ["docs", "typo"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page URL or path
+      placeholder: https://docs.vaner.ai/getting-started
+    validations:
+      required: true
+  - type: textarea
+    id: typo
+    attributes:
+      label: What should be corrected?
+      description: Share current text and your suggested fix.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What changed
+
+Describe the documentation changes.
+
+## Docs this affects
+
+- [ ] Getting started
+- [ ] Concepts
+- [ ] Configuration
+- [ ] Integrations
+- [ ] CLI
+- [ ] Security
+- [ ] Other
+
+## Preview
+
+- Vercel preview URL:
+
+## Validation
+
+- [ ] `npm run build` passes locally
+- [ ] Links in updated pages were checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Docs CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build docs site
+        run: npm run build

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,16 @@
+name: Link check
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 2 * * 1"
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check markdown links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: --verbose --no-progress "./**/*.md" "./**/*.mdx"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -13,4 +13,12 @@ jobs:
       - name: Check markdown links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
         with:
-          args: --verbose --no-progress "./**/*.md" "./**/*.mdx"
+          args: >-
+            --verbose
+            --no-progress
+            --base https://docs.vaner.ai
+            --exclude http://localhost:3000
+            --exclude https://github.com/Borgels/Vaner/security/policy
+            --exclude https://github.com/Borgels/Vaner/tree/main/examples
+            "./**/*.md"
+            "./**/*.mdx"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness
+- Respecting differing opinions and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and unwelcome sexual attention
+- Trolling, insulting, or derogatory comments
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at security@vaner.ai.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to vaner-docs
+
+Thanks for helping improve Vaner's public documentation.
+
+## Local development
+
+```bash
+npm ci
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+## Content structure
+
+- All docs pages live in `content/docs/`.
+- Use `meta.json` files to control sidebar ordering.
+- Keep user-facing language concise and implementation details accurate.
+
+## Style guide
+
+- Prefer direct, active voice.
+- Use sentence-case headings.
+- Keep examples copy-pasteable.
+- Link to canonical pages on `docs.vaner.ai` when referencing related concepts.
+
+## Pull requests
+
+- Keep each PR focused on one docs improvement.
+- Include a preview URL in the PR description.
+- Run `npm run build` before requesting review.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ Built with [Fumadocs](https://fumadocs.vercel.app) and Next.js.
 ## Development
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
 
+## Build check
+
+```bash
+npm run build
+```
+
 ## Content
 
 Documentation lives in `content/docs/`. Files are MDX and sidebar order is controlled by `meta.json` files.
+
+## Contributing
+
+- Contribution guide: `CONTRIBUTING.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
+- Security policy: `SECURITY.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+This repository only contains public documentation content and site code.
+
+For security vulnerabilities in Vaner, report privately through the main
+project policy:
+
+- https://github.com/Borgels/Vaner/security/policy

--- a/app/(docs)/[[...slug]]/page.tsx
+++ b/app/(docs)/[[...slug]]/page.tsx
@@ -16,11 +16,21 @@ export default async function Page({
   const { slug } = await params;
   const page = source.getPage(slug);
   if (!page) notFound();
+  const filePath = `content/docs/${slug && slug.length > 0 ? slug.join('/') : 'index'}.mdx`;
 
   const MDX = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      editOnGithub={{
+        owner: 'Borgels',
+        repo: 'vaner-docs',
+        sha: 'main',
+        path: filePath,
+      }}
+    >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -7,6 +7,14 @@ Vaner is a **local-first predictive context engine** for AI coding workflows.
 
 Think of it like a chess engine for context: during idle time, Vaner predicts likely next prompts, prepares useful context branches, and then serves the best package quickly when the real prompt arrives.
 
+<iframe
+  src="https://ghbtns.com/github-btn.html?user=Borgels&repo=Vaner&type=star&count=true&size=large"
+  title="Star Vaner on GitHub"
+  width="170"
+  height="30"
+  style={{ border: 0, overflow: "hidden" }}
+/>
+
 ## What Vaner does
 
 - Runs a background **ponder loop** to pre-build likely context.


### PR DESCRIPTION
## Summary
- add docs repo community-health and GitHub automation scaffolding
- wire Fumadocs `editOnGithub` for docs pages
- add GitHub star button on the docs landing page

## Test plan
- [ ] Docs CI passes
- [ ] verify `/` shows star button
- [ ] verify docs pages show edit-on-GitHub link

Made with [Cursor](https://cursor.com)