### PR TITLE
docs: introduce gateway+cockpit onboarding IA

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @abolsen

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Vaner code issues
+    url: https://github.com/Borgels/Vaner/issues
+    about: Report core product bugs in the main Vaner repository.
+  - name: Security disclosures
+    url: https://github.com/Borgels/Vaner/security/policy
+    about: Report vulnerabilities privately through the main repo security policy.

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,0 +1,19 @@
+name: Content request
+description: Request missing docs or improvements to existing docs
+title: "[docs] "
+labels: ["docs"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is missing or unclear?
+      description: Explain the current gap in docs.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Suggested improvement
+      description: Describe the desired content change.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/typo.yml
+++ b/.github/ISSUE_TEMPLATE/typo.yml
@@ -1,0 +1,19 @@
+name: Typo report
+description: Report typos, broken grammar, or wording issues
+title: "[typo] "
+labels: ["docs", "typo"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page URL or path
+      placeholder: https://docs.vaner.ai/getting-started
+    validations:
+      required: true
+  - type: textarea
+    id: typo
+    attributes:
+      label: What should be corrected?
+      description: Share current text and your suggested fix.
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## What changed
+
+Describe the documentation changes.
+
+## Docs this affects
+
+- [ ] Getting started
+- [ ] Concepts
+- [ ] Configuration
+- [ ] Integrations
+- [ ] CLI
+- [ ] Security
+- [ ] Other
+
+## Preview
+
+- Vercel preview URL:
+
+## Validation
+
+- [ ] `npm run build` passes locally
+- [ ] Links in updated pages were checked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: Docs CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build docs site
+        run: npm run build

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,16 @@
+name: Link check
+
+on:
+  pull_request:
+  schedule:
+    - cron: "17 2 * * 1"
+
+jobs:
+  lychee:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Check markdown links
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2
+        with:
+          args: --verbose --no-progress "./**/*.md" "./**/*.mdx"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness
+- Respecting differing opinions and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+Examples of unacceptable behavior:
+
+- Sexualized language or imagery, and unwelcome sexual attention
+- Trolling, insulting, or derogatory comments
+- Public or private harassment
+- Publishing others' private information without explicit permission
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers at security@vaner.ai.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to vaner-docs
+
+Thanks for helping improve Vaner's public documentation.
+
+## Local development
+
+```bash
+npm ci
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+## Content structure
+
+- All docs pages live in `content/docs/`.
+- Use `meta.json` files to control sidebar ordering.
+- Keep user-facing language concise and implementation details accurate.
+
+## Style guide
+
+- Prefer direct, active voice.
+- Use sentence-case headings.
+- Keep examples copy-pasteable.
+- Link to canonical pages on `docs.vaner.ai` when referencing related concepts.
+
+## Pull requests
+
+- Keep each PR focused on one docs improvement.
+- Include a preview URL in the PR description.
+- Run `npm run build` before requesting review.

--- a/README.md
+++ b/README.md
@@ -7,12 +7,24 @@ Built with [Fumadocs](https://fumadocs.vercel.app) and Next.js.
 ## Development
 
 ```bash
-npm install
+npm ci
 npm run dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000).
 
+## Build check
+
+```bash
+npm run build
+```
+
 ## Content
 
 Documentation lives in `content/docs/`. Files are MDX and sidebar order is controlled by `meta.json` files.
+
+## Contributing
+
+- Contribution guide: `CONTRIBUTING.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
+- Security policy: `SECURITY.md`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+This repository only contains public documentation content and site code.
+
+For security vulnerabilities in Vaner, report privately through the main
+project policy:
+
+- https://github.com/Borgels/Vaner/security/policy

--- a/app/(docs)/[[...slug]]/page.tsx
+++ b/app/(docs)/[[...slug]]/page.tsx
@@ -16,11 +16,21 @@ export default async function Page({
   const { slug } = await params;
   const page = source.getPage(slug);
   if (!page) notFound();
+  const filePath = `content/docs/${slug && slug.length > 0 ? slug.join('/') : 'index'}.mdx`;
 
   const MDX = page.data.body;
 
   return (
-    <DocsPage toc={page.data.toc} full={page.data.full}>
+    <DocsPage
+      toc={page.data.toc}
+      full={page.data.full}
+      editOnGithub={{
+        owner: 'Borgels',
+        repo: 'vaner-docs',
+        sha: 'main',
+        path: filePath,
+      }}
+    >
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -1,31 +1,33 @@
 ---
 title: Architecture
-description: How Vaner combines idle-time preparation with fast prompt-time delivery.
+description: How Vaner runs beside your model and serves scenarios over MCP.
 ---
 
-Vaner has two loops:
+Vaner has two interfaces and one default stance:
 
-- **Ponder loop (idle path):** predicts likely next prompts, explores plausible branches, and pre-builds artifacts.
-- **Answer loop (hot path):** ranks and assembles the best context package for the real prompt.
+- **Human interface (cockpit):** CLI, IDE panel, and local HTTP UI for visibility and controls.
+- **Model interface (MCP):** tool-driven pull of prepared scenarios.
+- **Default stance:** side-running, local-first, not on the request hot path.
 
 ## Core components
 
-### Behavioral memory and intent modeling
+### Ponder loop and scenario builder
 
-Vaner adapts to workflow patterns over time using local history and recent interactions.
+The daemon watches repo activity, generates artifacts, and continuously builds ranked scenarios into `scenarios.db`.
 
-### Exploration frontier
+### Scenario store and scoring
 
-The planner admits and prioritizes speculative scenarios from graph signals, conversation flow, and prompt patterns.
+Each scenario stores prepared context, evidence references, freshness, expansion cost, and feedback outcome.
+Vaner re-scores scenarios so models can pick the most promising one quickly.
 
-### Artifact store and replay memory
+### MCP runtime (model pull)
 
-Vaner persists prepared context artifacts and replayable evidence so prompt-time decisions stay fast.
+MCP tools (`list_scenarios`, `get_scenario`, `expand_scenario`, `compare_scenarios`, `report_outcome`) expose the prepared cheat sheet on demand.
 
-### Prompt-time broker
+### Cockpit runtime (human controls)
 
-When a real prompt arrives, the broker scores candidate artifacts under token and privacy constraints, then returns the best package.
+Cockpit endpoints show status, freshness distribution, device configuration, and live scenario stream updates.
 
-### Safety and policy gate
+### Optional gateway capability
 
-Every package is filtered by explicit path scope, exclusion rules, and redaction policy before delivery.
+`vaner proxy` remains available for clients that only support OpenAI-compatible endpoints, but it is not required for MCP-first usage.

--- a/content/docs/cli.mdx
+++ b/content/docs/cli.mdx
@@ -1,25 +1,50 @@
 ---
 title: CLI Reference
-description: Core Vaner CLI commands for setup, runtime, and inspection.
+description: Core Vaner CLI commands for MCP-first setup, cockpit, and scenarios.
 ---
 
-## Common commands
+## Setup and daemon
 
 ```bash
 vaner init --profile minimal --path .
 vaner daemon start --no-once --path .
+vaner daemon serve-http --path .
 vaner daemon status --path .
 vaner daemon stop --path .
-vaner query "where is auth enforced?" --path .
-vaner inspect --last --path .
 ```
 
-## Integration commands
+## Scenario cockpit commands
+
+```bash
+vaner scenarios list --limit 10 --path .
+vaner scenarios show <scenario_id> --path .
+vaner scenarios expand <scenario_id> --path .
+vaner scenarios compare <scenario_a> <scenario_b> --path .
+vaner scenarios outcome <scenario_id> useful --path .
+```
+
+## Live monitoring and diagnostics
+
+```bash
+vaner watch --cockpit-url http://127.0.0.1:8473
+vaner show --cockpit-url http://127.0.0.1:8473
+vaner status --path .
+vaner doctor --path .
+```
+
+## MCP server
+
+```bash
+vaner mcp --path .
+vaner mcp --path . --transport sse --host 127.0.0.1 --port 8472
+```
+
+## Optional capability: OpenAI-compatible gateway
 
 ```bash
 vaner proxy --path . --host 127.0.0.1 --port 8471
-vaner proxy --context-only --path . --host 127.0.0.1 --port 8472
-vaner mcp --path .
 ```
+
+Use this only when your client cannot call MCP tools directly.
 
 Run `vaner --help` and `vaner <subcommand> --help` for full flags.

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configure backends, privacy boundaries, and runtime limits.
+description: Configure MCP, exploration, privacy boundaries, and optional gateway behavior.
 ---
 
 Vaner reads configuration from `.vaner/config.toml`.
@@ -13,26 +13,38 @@ base_url = "http://127.0.0.1:11434/v1"
 model = "qwen2.5-coder:32b"
 api_key_env = "OLLAMA_API_KEY"
 
-[proxy]
-allow_repo_override = false
-max_requests_per_minute = 120
+[mcp]
+transport = "stdio"
+http_host = "127.0.0.1"
+http_port = 8472
+
+[exploration]
+enabled = true
+mode = "idle_only"
+budget_pct = 0.3
+
+[gateway.passthrough]
+enabled = false
 
 [privacy]
 allowed_paths = ["src/**", "docs/**"]
 excluded_patterns = ["*.env", "*.key", "*.pem", "credentials*", "secrets*"]
 redact_patterns = ["sk-[a-zA-Z0-9_-]{20,}"]
 
-[limits]
-max_age_seconds = 3600
-max_context_tokens = 4096
+[compute]
+device = "cpu"
+cpu_fraction = 0.25
+gpu_memory_fraction = 0.4
+idle_only = true
 ```
 
 ## Key sections
 
-- `backend`: default upstream endpoint and model.
-- `backends.<name>`: optional named backend profiles.
-- `proxy`: HTTP behavior, auth, and rate limits.
+- `mcp`: MCP server transport and host/port for SSE mode.
+- `exploration`: controls speculative scenario preparation behavior.
+- `gateway.passthrough`: optional OpenAI-compatible proxy capability (`false` by default).
+- `backend`: local/runtime model endpoint used by the exploration loop.
 - `privacy`: include/exclude/redaction rules.
-- `limits`: freshness and token budgets.
+- `compute`: CPU/GPU limits and idle-only guardrails.
 
 Use `vaner init --profile minimal|advanced|multi` to scaffold configs with different detail levels.

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -1,9 +1,46 @@
 ---
 title: Getting Started
-description: Install Vaner, initialize a workspace, and run your first query.
+description: Install Vaner, connect your IDE, and verify Vaner is working in three steps.
 ---
 
-## Install
+## 1) Install Vaner
+
+```bash
+curl -fsSL https://vaner.ai/install.sh | bash
+```
+
+The installer supports Linux/macOS and can be used non-interactively in CI.
+
+### Review script before running
+
+- Canonical source: [github.com/Borgels/vaner/blob/main/scripts/install.sh](https://github.com/Borgels/vaner/blob/main/scripts/install.sh)
+- Hosted URL: `https://vaner.ai/install.sh`
+
+### Installer options
+
+```bash
+# Non-interactive (CI)
+curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes
+
+# Force backend
+curl -fsSL https://vaner.ai/install.sh | bash -s -- --backend pipx
+
+# Dry-run / verify
+curl -fsSL https://vaner.ai/install.sh | bash -s -- --dry-run
+curl -fsSL https://vaner.ai/install.sh | bash -s -- --verify
+```
+
+Environment variable mirrors:
+
+- `VANER_YES=1`
+- `VANER_DRY_RUN=1`
+- `VANER_VERIFY=1`
+- `VANER_BACKEND=uv|pipx`
+- `VANER_VERSION=<version>`
+- `VANER_NO_MODIFY_PATH=1`
+- `VANER_VERBOSE=1`
+
+### From source / contributors
 
 ```bash
 python -m venv .venv
@@ -11,20 +48,31 @@ source .venv/bin/activate
 pip install -e ".[dev]"
 ```
 
-## Initialize and run
+## 2) Initialize and connect your IDE
 
 ```bash
-vaner init --profile minimal --path .
-vaner daemon start --no-once --path .
-vaner query "where is auth enforced?" --path .
-vaner inspect --last --path .
+vaner init --path .
+vaner proxy --path .
 ```
 
-## Choose an integration mode
+Then:
 
-- **Proxy mode** (`/v1/chat/completions`): best when tools expect OpenAI-compatible APIs.
-- **MCP mode**: best when your IDE supports MCP natively.
-- **Context-only mode** (`/v1/context`): best when your agent handles model routing and only needs context.
-- **Python SDK**: best for scripts and custom automation.
+- Set your IDE/provider base URL to `http://127.0.0.1:8471/v1`.
+- Keep your existing API key and model picker in the IDE.
+- Optional: install the VS Code/Cursor extension from `ide/vscode/` for built-in cockpit UI.
 
-See [Integrations](/integrations) for details.
+## 3) Verify it works
+
+```bash
+vaner watch --limit 3
+vaner status
+vaner impact
+vaner show
+```
+
+- `watch` proves traffic is flowing through Vaner.
+- `status` confirms proxy/backend/compute configuration.
+- `impact` summarizes sampled before/after shadow comparisons.
+- `show` opens the local web cockpit.
+
+For advanced integrations (MCP, context-only, SDK), see [Integrations](/integrations).

--- a/content/docs/how-it-works.mdx
+++ b/content/docs/how-it-works.mdx
@@ -1,0 +1,36 @@
+---
+title: How It Works
+description: Vaner's gateway + cockpit architecture.
+---
+
+Vaner has two surfaces:
+
+- **Gateway**: request path that enriches prompts with context while preserving your IDE model selection.
+- **Cockpit**: visibility path that shows what Vaner did and whether it helped.
+
+```mermaid
+flowchart LR
+    IDE[IDE]
+    Gateway[VanerGateway]
+    Provider[ModelProvider]
+    Cockpit[Cockpit]
+    IDE -->|OPENAI_BASE_URL localhost| Gateway
+    Gateway -->|enriched request| Provider
+    Provider -->|response| Gateway
+    Gateway -->|response| IDE
+    Gateway -->|decision stream| Cockpit
+```
+
+## Request path
+
+1. IDE sends a request to `http://127.0.0.1:8471/v1/chat/completions`.
+2. Vaner computes context from repo state.
+3. Vaner forwards to your backend provider.
+4. Response returns in OpenAI-compatible shape.
+
+## Visibility path
+
+- `vaner watch`: live request/decision feed.
+- `vaner impact`: sampled shadow comparison summary.
+- `vaner show`: local cockpit UI at `/ui`.
+- VS Code/Cursor extension: status bar + side panel.

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,11 +1,11 @@
 ---
 title: Introduction
-description: Vaner is a local-first predictive context engine that prepares context before you ask.
+description: Vaner is local-first context infrastructure that rides alongside your IDE model flow.
 ---
 
-Vaner is a **local-first predictive context engine** for AI coding workflows.
+Vaner is a **local-first context gateway + cockpit** for AI coding workflows.
 
-Think of it like a chess engine for context: during idle time, Vaner predicts likely next prompts, prepares useful context branches, and then serves the best package quickly when the real prompt arrives.
+Your IDE keeps its model picker. Vaner sits in the middle, enriches requests with context, and gives you visibility into what happened.
 
 <iframe
   src="https://ghbtns.com/github-btn.html?user=Borgels&repo=Vaner&type=star&count=true&size=large"
@@ -17,9 +17,9 @@ Think of it like a chess engine for context: during idle time, Vaner predicts li
 
 ## What Vaner does
 
-- Runs a background **ponder loop** to pre-build likely context.
-- Runs a prompt-time **answer loop** to rank and assemble the best context package.
-- Stays **model-agnostic**, so you can use local or cloud backends without lock-in.
+- Uses idle local hardware to prepare context ahead of requests.
+- Enriches prompt-time requests through an OpenAI-shaped gateway.
+- Surfaces live decisions in CLI, local web cockpit, and IDE extension.
 
 ## Core outcomes
 
@@ -32,6 +32,7 @@ Vaner is successful when it improves one or more of:
 ## Start here
 
 - New users: [Getting started](/getting-started)
-- Concepts and terminology: [Concepts](/concepts)
-- Setup and tuning: [Configuration](/configuration)
-- Integration modes: [Integrations](/integrations)
+- Mental model: [How it works](/how-it-works)
+- Prove it is helping: [See it working](/see-it-working)
+- Setup and tuning: [Configuration](/configuration) and [Compute tuning](/tuning/compute)
+- Advanced integrations: [Integrations](/integrations)

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -7,6 +7,14 @@ Vaner is a **local-first predictive context engine** for AI coding workflows.
 
 Think of it like a chess engine for context: during idle time, Vaner predicts likely next prompts, prepares useful context branches, and then serves the best package quickly when the real prompt arrives.
 
+<iframe
+  src="https://ghbtns.com/github-btn.html?user=Borgels&repo=Vaner&type=star&count=true&size=large"
+  title="Star Vaner on GitHub"
+  width="170"
+  height="30"
+  style={{ border: 0, overflow: "hidden" }}
+/>
+
 ## What Vaner does
 
 - Runs a background **ponder loop** to pre-build likely context.

--- a/content/docs/integrations/_generated.json
+++ b/content/docs/integrations/_generated.json
@@ -1,0 +1,289 @@
+{
+  "$schema": "./compatibility.schema.json",
+  "version": 1,
+  "tools": [
+    {
+      "slug": "cursor-mcp",
+      "name": "Cursor",
+      "category": "ide",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/cursor-mcp.md",
+      "example_path": "examples/cursor-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "claude-code-mcp",
+      "name": "Claude Code",
+      "category": "cli",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/claude-code-mcp.md",
+      "example_path": "examples/claude-code-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "claude-desktop-mcp",
+      "name": "Claude Desktop",
+      "category": "agent-host",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/claude-desktop-mcp.md",
+      "example_path": "examples/claude-desktop-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "zed-mcp",
+      "name": "Zed",
+      "category": "ide",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/zed-mcp.md",
+      "example_path": "examples/zed-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "windsurf-mcp",
+      "name": "Windsurf",
+      "category": "ide",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/windsurf-mcp.md",
+      "example_path": "examples/windsurf-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "vscode-copilot-agent-mcp",
+      "name": "VS Code Copilot Agent",
+      "category": "ide",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/vscode-copilot-agent-mcp.md",
+      "example_path": "examples/vscode-copilot-agent-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": "Agent mode only"
+    },
+    {
+      "slug": "codex-cli-mcp",
+      "name": "Codex CLI",
+      "category": "cli",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/codex-cli-mcp.md",
+      "example_path": "examples/codex-cli-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "continue-mcp",
+      "name": "Continue (MCP)",
+      "category": "ide",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/continue-mcp.md",
+      "example_path": "examples/continue-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "openclaw-mcp",
+      "name": "OpenClaw",
+      "category": "agent-host",
+      "mode": "mcp",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "mcp"
+      ],
+      "doc_path": "docs/integrations/openclaw-mcp.md",
+      "example_path": "examples/openclaw-mcp/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "aider-proxy",
+      "name": "Aider",
+      "category": "cli",
+      "mode": "proxy",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "proxy"
+      ],
+      "doc_path": "docs/integrations/aider-proxy.md",
+      "example_path": "examples/aider-proxy/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "continue-proxy",
+      "name": "Continue (Proxy)",
+      "category": "ide",
+      "mode": "proxy",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "proxy"
+      ],
+      "doc_path": "docs/integrations/continue-proxy.md",
+      "example_path": "examples/continue-proxy/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "lm-studio-client-proxy",
+      "name": "LM Studio (client)",
+      "category": "web-ui",
+      "mode": "proxy",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "proxy"
+      ],
+      "doc_path": "docs/integrations/lm-studio-client-proxy.md",
+      "example_path": "examples/lm-studio-client-proxy/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "openrouter-backend-proxy",
+      "name": "OpenRouter",
+      "category": "proxy",
+      "mode": "proxy",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "proxy",
+        "backend"
+      ],
+      "doc_path": "docs/integrations/openrouter-backend-proxy.md",
+      "example_path": "examples/openrouter-backend-proxy/",
+      "verified_on": "2026-04-19",
+      "notes": "Used as upstream backend behind Vaner proxy"
+    },
+    {
+      "slug": "vllm-backend",
+      "name": "vLLM",
+      "category": "backend",
+      "mode": "backend",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "backend"
+      ],
+      "doc_path": "docs/integrations/vllm-backend.md",
+      "example_path": "examples/vllm-backend/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "hf-inference-endpoints-backend",
+      "name": "Hugging Face Inference Endpoints",
+      "category": "backend",
+      "mode": "backend",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "backend"
+      ],
+      "doc_path": "docs/integrations/hf-inference-endpoints-backend.md",
+      "example_path": "examples/hf-inference-endpoints-backend/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "lm-studio-backend",
+      "name": "LM Studio (backend)",
+      "category": "backend",
+      "mode": "backend",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "backend"
+      ],
+      "doc_path": "docs/integrations/lm-studio-backend.md",
+      "example_path": "examples/lm-studio-backend/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    },
+    {
+      "slug": "ollama-backend",
+      "name": "Ollama",
+      "category": "backend",
+      "mode": "backend",
+      "status": "supported",
+      "install_effort": "docs-only",
+      "surfaces": [
+        "backend"
+      ],
+      "doc_path": "docs/integrations/ollama-backend.md",
+      "example_path": "examples/ollama-backend/",
+      "verified_on": "2026-04-19",
+      "notes": ""
+    }
+  ],
+  "unsupported": [
+    {
+      "name": "ChatGPT (consumer web/app)",
+      "reason": "No local proxy or MCP attach point for third-party middleware.",
+      "re_evaluate_when": "If OpenAI exposes local middleware/plugin hooks for consumer ChatGPT."
+    },
+    {
+      "name": "Microsoft Copilot (consumer / Microsoft 365)",
+      "reason": "Closed hosted product with no local context-injection attach point.",
+      "re_evaluate_when": "If Microsoft exposes local plugin or MCP endpoints for this product tier."
+    },
+    {
+      "name": "Perplexity (consumer)",
+      "reason": "No local attach point for Vaner proxy or MCP-based retrieval.",
+      "re_evaluate_when": "If Perplexity adds extensible local tools/middleware APIs."
+    },
+    {
+      "name": "Google Gemini app (consumer)",
+      "reason": "Consumer app does not expose local middleware integration points.",
+      "re_evaluate_when": "If Gemini consumer product supports local tools or middleware hooks."
+    },
+    {
+      "name": "Replit Ghostwriter",
+      "reason": "Hosted assistant does not provide local middleware insertion for Vaner.",
+      "re_evaluate_when": "If Replit enables local agent/plugin attach points for Ghostwriter."
+    }
+  ]
+}

--- a/content/docs/integrations/advanced.mdx
+++ b/content/docs/integrations/advanced.mdx
@@ -1,0 +1,14 @@
+---
+title: Advanced Tool Recipes
+description: Tool-specific setup pages for MCP/proxy/backend combinations.
+---
+
+Tool-specific recipes are grouped under `/integrations/tools/*`.
+
+Start with:
+
+- [Cursor MCP](/integrations/tools/cursor-mcp)
+- [VS Code Copilot Agent MCP](/integrations/tools/vscode-copilot-agent-mcp)
+- [Continue Proxy](/integrations/tools/continue-proxy)
+
+If you are new to Vaner, use [Getting Started](/getting-started) first.

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -1,17 +1,17 @@
 ---
 title: Integrations
-description: Advanced integration paths for tools and runtimes beyond the default gateway+cockpit flow.
+description: MCP-first integration paths for IDEs, runtimes, and optional compatibility layers.
 ---
 
-Default onboarding is gateway + cockpit (`vaner proxy`, `vaner watch`, `vaner show`).
-This section covers advanced alternatives and tool-specific recipes.
+Default onboarding is MCP + cockpit (`vaner mcp`, `vaner watch`, `vaner show`).
+This section covers integration modes and tool-specific recipes.
 
-## Advanced integration modes
+## Integration modes
 
-- [Proxy mode](/integrations/proxy): OpenAI-compatible `/v1/chat/completions` endpoint.
-- [MCP mode](/integrations/mcp): native IDE integration where the IDE handles model calls.
-- [Context-only mode](/integrations/context-only): `/v1/context` for agent frameworks.
+- [MCP mode](/integrations/mcp): native IDE integration where models pull scenario context via tools.
 - [Python SDK mode](/integrations/python-sdk): direct library usage for scripts and tooling.
+- [Context-only mode](/integrations/context-only): `/v1/context` for agent frameworks.
+- [Proxy mode](/integrations/proxy): optional OpenAI-compatible `/v1/chat/completions` capability.
 
 For local multi-service setups, see [Docker](/integrations/docker).
 

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -1,9 +1,12 @@
 ---
 title: Integrations
-description: Choose the right Vaner integration mode for your tools.
+description: Advanced integration paths for tools and runtimes beyond the default gateway+cockpit flow.
 ---
 
-Vaner supports four primary integration modes:
+Default onboarding is gateway + cockpit (`vaner proxy`, `vaner watch`, `vaner show`).
+This section covers advanced alternatives and tool-specific recipes.
+
+## Advanced integration modes
 
 - [Proxy mode](/integrations/proxy): OpenAI-compatible `/v1/chat/completions` endpoint.
 - [MCP mode](/integrations/mcp): native IDE integration where the IDE handles model calls.
@@ -11,3 +14,8 @@ Vaner supports four primary integration modes:
 - [Python SDK mode](/integrations/python-sdk): direct library usage for scripts and tooling.
 
 For local multi-service setups, see [Docker](/integrations/docker).
+
+## Tool Compatibility
+
+- [Compatibility matrix](/integrations/compatibility): grouped tool status across IDEs, CLIs, backends, and hosts.
+- [Tool-specific pages](/integrations/tools/cursor-mcp): per-tool install and verification routes.

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -2,6 +2,9 @@
   "title": "Integrations",
   "pages": [
     "index",
+    "advanced",
+    "compatibility",
+    "tools",
     "proxy",
     "mcp",
     "context-only",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -3,9 +3,12 @@
   "pages": [
     "index",
     "getting-started",
+    "how-it-works",
+    "see-it-working",
     "concepts",
     "architecture",
     "configuration",
+    "tuning",
     "integrations",
     "backends",
     "cli",

--- a/content/docs/see-it-working.mdx
+++ b/content/docs/see-it-working.mdx
@@ -1,45 +1,41 @@
 ---
 title: See It Working
-description: Verify traffic, quality signals, and latency/cost impact.
+description: Verify scenario prep, MCP pull flow, and cockpit feedback.
 ---
 
-## Live flow
+## Start the local cockpit
 
 ```bash
+vaner daemon serve-http --path .
 vaner watch
 ```
 
-You should see lines like:
+You should see scenario events like:
 
 ```text
-[hit] 214 tok • 8 files • decision abc123
+[change] score=0.885 freshness=fresh scenario scn_1a2b3c4d5e6f7g8h
 ```
 
-## Health snapshot
+## Check readiness
 
 ```bash
 vaner status
 vaner doctor
+vaner scenarios list --limit 5
 ```
 
-Use this to confirm proxy reachability, backend config, and compute limits.
+Use this to confirm cockpit reachability, MCP readiness, local runtime health, and scenario freshness.
 
-## Before/after summary
+## Pull scenarios through MCP
 
-Enable shadow sampling in `.vaner/config.toml`:
+In your MCP-capable IDE (Cursor/Claude), call:
 
-```toml
-[gateway.shadow]
-rate = 0.05
-```
+- `list_scenarios`
+- `get_scenario` with the returned `id`
+- `expand_scenario` to refresh a candidate
+- `report_outcome` with `useful|partial|irrelevant`
 
-Then run:
-
-```bash
-vaner impact
-```
-
-This reports sampled pair count, win rate, and latency delta.
+This confirms the MCP-first flow: Vaner prepares scenarios on the side and the model pulls context on demand.
 
 ## Visual cockpit
 
@@ -47,4 +43,4 @@ This reports sampled pair count, win rate, and latency delta.
 vaner show
 ```
 
-Opens the local cockpit with status, impact summary, compute controls, and latest decision event.
+Opens the local cockpit with live scenarios, compute controls, and the latest scenario updates.

--- a/content/docs/see-it-working.mdx
+++ b/content/docs/see-it-working.mdx
@@ -1,0 +1,50 @@
+---
+title: See It Working
+description: Verify traffic, quality signals, and latency/cost impact.
+---
+
+## Live flow
+
+```bash
+vaner watch
+```
+
+You should see lines like:
+
+```text
+[hit] 214 tok • 8 files • decision abc123
+```
+
+## Health snapshot
+
+```bash
+vaner status
+vaner doctor
+```
+
+Use this to confirm proxy reachability, backend config, and compute limits.
+
+## Before/after summary
+
+Enable shadow sampling in `.vaner/config.toml`:
+
+```toml
+[gateway.shadow]
+rate = 0.05
+```
+
+Then run:
+
+```bash
+vaner impact
+```
+
+This reports sampled pair count, win rate, and latency delta.
+
+## Visual cockpit
+
+```bash
+vaner show
+```
+
+Opens the local cockpit with status, impact summary, compute controls, and latest decision event.

--- a/content/docs/tuning/compute.mdx
+++ b/content/docs/tuning/compute.mdx
@@ -1,0 +1,32 @@
+---
+title: Compute Tuning
+description: Control CPU/GPU usage and device routing for Vaner.
+---
+
+Vaner reads compute settings from `.vaner/config.toml`.
+
+```toml
+[compute]
+device = "auto"               # auto | cpu | cuda:0 | cuda:1 | mps
+cpu_fraction = 0.2
+gpu_memory_fraction = 0.5
+embedding_device = "cuda"
+exploration_concurrency = 4
+max_parallel_precompute = 1
+```
+
+## CLI updates
+
+```bash
+vaner config set compute.device cuda:1
+vaner config set compute.cpu_fraction 0.2
+vaner config set compute.gpu_memory_fraction 0.5
+```
+
+## Inspect available devices
+
+```bash
+curl http://127.0.0.1:8471/compute/devices
+```
+
+or use `vaner show` / the VS Code extension cockpit panel.

--- a/content/docs/tuning/meta.json
+++ b/content/docs/tuning/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Tuning",
+  "pages": ["compute"]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "prebuild": "node --experimental-strip-types scripts/fetch-integrations.ts",
+    "sync:integrations": "node --experimental-strip-types scripts/fetch-integrations.ts"
   },
   "dependencies": {
     "fumadocs-core": "^16",

--- a/scripts/fetch-integrations.ts
+++ b/scripts/fetch-integrations.ts
@@ -1,0 +1,52 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const RAW_MANIFEST_URL =
+  "https://raw.githubusercontent.com/Borgels/Vaner/main/docs/integrations/compatibility.json";
+
+const DEFAULT_LOCAL_MANIFEST = "/home/abo/repos/Vaner/docs/integrations/compatibility.json";
+const GENERATED_FALLBACK = resolve(process.cwd(), "content/docs/integrations/_generated.json");
+
+function parseArgs(): { source?: string } {
+  const args = process.argv.slice(2);
+  const sourceArg = args.find((arg) => arg.startsWith("--source="));
+  return { source: sourceArg ? sourceArg.slice("--source=".length) : undefined };
+}
+
+async function readManifestText(source?: string): Promise<string> {
+  const localPath = source || process.env.VANER_COMPATIBILITY_PATH || DEFAULT_LOCAL_MANIFEST;
+
+  try {
+    return await readFile(localPath, "utf-8");
+  } catch {
+    const response = await fetch(RAW_MANIFEST_URL, { cache: "no-store" });
+    if (response.ok) {
+      return await response.text();
+    }
+  }
+
+  try {
+    const fallback = await readFile(GENERATED_FALLBACK, "utf-8");
+    console.warn(`Using fallback manifest from ${GENERATED_FALLBACK}`);
+    return fallback;
+  } catch {
+    throw new Error("Failed to load compatibility manifest from local path, remote URL, and generated fallback.");
+  }
+}
+
+async function main(): Promise<void> {
+  const { source } = parseArgs();
+  const text = await readManifestText(source);
+  const parsed = JSON.parse(text);
+
+  const outPath = resolve(process.cwd(), "content/docs/integrations/_generated.json");
+  await mkdir(resolve(process.cwd(), "content/docs/integrations"), { recursive: true });
+  await writeFile(outPath, JSON.stringify(parsed, null, 2) + "\n", "utf-8");
+
+  console.log(`Wrote ${outPath}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- rewrite core docs pages around the local-first gateway+cockpit mental model and three-step onboarding
- add new pages for architecture (`how-it-works`), verification (`see-it-working`), and compute controls (`tuning/compute`)
- harden integration sync prebuild by falling back to committed generated manifest when upstream compatibility metadata is unavailable

## Test plan
- [x] `npm run build`

Made with [Cursor](https://cursor.com)