### PR TITLE
feat(mcp): client picker + per-tool guides + /mcp hub

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,9 +16,12 @@ jobs:
           args: >-
             --verbose
             --no-progress
-            --root-dir .
+            --base https://docs.vaner.ai
             --exclude http://localhost:3000
             --exclude https://github.com/Borgels/Vaner/security/policy
             --exclude https://github.com/Borgels/Vaner/tree/main/examples
+            --exclude https://docs.vaner.ai/mcp
+            --exclude https://docs.vaner.ai/integrations/tools/claude-code-mcp
+            --exclude https://docs.vaner.ai/scenarios
             "./**/*.md"
             "./**/*.mdx"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,6 +16,7 @@ jobs:
           args: >-
             --verbose
             --no-progress
+            --root-dir .
             --exclude http://localhost:3000
             --exclude https://github.com/Borgels/Vaner/security/policy
             --exclude https://github.com/Borgels/Vaner/tree/main/examples

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,6 @@ jobs:
           args: >-
             --verbose
             --no-progress
-            --base https://docs.vaner.ai
             --exclude http://localhost:3000
             --exclude https://github.com/Borgels/Vaner/security/policy
             --exclude https://github.com/Borgels/Vaner/tree/main/examples

--- a/app/(docs)/[[...slug]]/page.tsx
+++ b/app/(docs)/[[...slug]]/page.tsx
@@ -7,6 +7,7 @@ import {
 } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
+import { useMDXComponents } from '@/mdx-components';
 
 export default async function Page({
   params,
@@ -17,6 +18,7 @@ export default async function Page({
   const page = source.getPage(slug);
   if (!page) notFound();
   const filePath = `content/docs/${slug && slug.length > 0 ? slug.join('/') : 'index'}.mdx`;
+  const mdxComponents = useMDXComponents({});
 
   const MDX = page.data.body;
 
@@ -34,7 +36,7 @@ export default async function Page({
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
-        <MDX />
+        <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>
   );

--- a/components/mcp/backend-picker-server.tsx
+++ b/components/mcp/backend-picker-server.tsx
@@ -1,0 +1,23 @@
+import { getMcpBackends, type McpBackend } from '@/lib/mcp-clients';
+import { BackendPresetPicker } from './backend-picker';
+
+type Props = {
+  initialBackend?: string;
+  compact?: boolean;
+  only?: string[];
+};
+
+export function BackendPresetPickerServer({ initialBackend, compact, only }: Props) {
+  let backends: McpBackend[] = getMcpBackends();
+  if (only && only.length > 0) {
+    const set = new Set(only);
+    backends = backends.filter((b) => set.has(b.id));
+  }
+  return (
+    <BackendPresetPicker
+      backends={backends}
+      initialBackend={initialBackend}
+      compact={compact}
+    />
+  );
+}

--- a/components/mcp/backend-picker.tsx
+++ b/components/mcp/backend-picker.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
+import { Tabs, TabsList, TabsTrigger } from 'fumadocs-ui/components/ui/tabs';
 import type { McpBackend } from '@/lib/mcp-clients';
 
 type Props = {
@@ -25,28 +28,20 @@ export function BackendPresetPicker({ backends, initialBackend, compact }: Props
 
   return (
     <div className={`my-6 rounded-xl border border-border bg-card p-4 ${compact ? '' : ''}`}>
-      <label className="mb-3 block text-xs text-muted-foreground">
-        <span className="mb-1 block font-medium text-foreground">Backend</span>
-        <select
-          value={active.id}
-          onChange={(e) => setBackendId(e.target.value)}
-          className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
-        >
-          {ordered.map((b) => (
-            <option key={b.id} value={b.id}>
-              {b.name}
-              {b.requiresKey ? ' · needs API key' : ''}
-            </option>
+      <Tabs value={active.id} onValueChange={setBackendId} className="mb-3">
+        <TabsList>
+          {ordered.map((backend) => (
+            <TabsTrigger key={backend.id} value={backend.id}>
+              {backend.name}
+            </TabsTrigger>
           ))}
-        </select>
-      </label>
+        </TabsList>
+      </Tabs>
 
       <p className="mb-2 text-xs text-muted-foreground">{active.setupHint}</p>
 
       <div className="relative">
-        <pre className="max-h-60 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
-          <code>{active.snippet}</code>
-        </pre>
+        <DynamicCodeBlock lang="toml" code={active.snippet} />
         <button
           type="button"
           onClick={async () => {
@@ -64,12 +59,11 @@ export function BackendPresetPicker({ backends, initialBackend, compact }: Props
         </button>
       </div>
 
-      <p className="mt-3 text-xs text-muted-foreground">
-        Upstream:{' '}
-        <a href={active.url} className="underline underline-offset-2" rel="noreferrer noopener" target="_blank">
+      <Cards className="mt-3">
+        <Card title="Upstream" href={active.url} external>
           {active.url}
-        </a>
-      </p>
+        </Card>
+      </Cards>
     </div>
   );
 }

--- a/components/mcp/backend-picker.tsx
+++ b/components/mcp/backend-picker.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { McpBackend } from '@/lib/mcp-clients';
+
+type Props = {
+  backends: McpBackend[];
+  initialBackend?: string;
+  compact?: boolean;
+};
+
+export function BackendPresetPicker({ backends, initialBackend, compact }: Props) {
+  const ordered = useMemo(() => {
+    if (!initialBackend) return backends;
+    const first = backends.find((b) => b.id === initialBackend);
+    if (!first) return backends;
+    return [first, ...backends.filter((b) => b.id !== first.id)];
+  }, [backends, initialBackend]);
+
+  const [backendId, setBackendId] = useState(initialBackend ?? ordered[0]?.id);
+  const active = ordered.find((b) => b.id === backendId) ?? ordered[0];
+  const [copied, setCopied] = useState(false);
+
+  if (!active) return null;
+
+  return (
+    <div className={`my-6 rounded-xl border border-border bg-card p-4 ${compact ? '' : ''}`}>
+      <label className="mb-3 block text-xs text-muted-foreground">
+        <span className="mb-1 block font-medium text-foreground">Backend</span>
+        <select
+          value={active.id}
+          onChange={(e) => setBackendId(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
+        >
+          {ordered.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name}
+              {b.requiresKey ? ' · needs API key' : ''}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <p className="mb-2 text-xs text-muted-foreground">{active.setupHint}</p>
+
+      <div className="relative">
+        <pre className="max-h-60 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
+          <code>{active.snippet}</code>
+        </pre>
+        <button
+          type="button"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(active.snippet);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            } catch {
+              /* ignore */
+            }
+          }}
+          className="absolute right-2 top-2 rounded-md border border-border bg-background px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          {copied ? 'Copied' : 'Copy TOML'}
+        </button>
+      </div>
+
+      <p className="mt-3 text-xs text-muted-foreground">
+        Upstream:{' '}
+        <a href={active.url} className="underline underline-offset-2" rel="noreferrer noopener" target="_blank">
+          {active.url}
+        </a>
+      </p>
+    </div>
+  );
+}

--- a/components/mcp/client-picker-server.tsx
+++ b/components/mcp/client-picker-server.tsx
@@ -1,0 +1,25 @@
+import { getMcpClients, type McpClient } from '@/lib/mcp-clients';
+import { McpClientPicker } from './client-picker';
+
+type Props = {
+  initialClient?: string;
+  lockClient?: boolean;
+  compact?: boolean;
+  only?: string[];
+};
+
+export function McpClientPickerServer({ initialClient, lockClient, compact, only }: Props) {
+  let clients: McpClient[] = getMcpClients();
+  if (only && only.length > 0) {
+    const set = new Set(only);
+    clients = clients.filter((c) => set.has(c.id));
+  }
+  return (
+    <McpClientPicker
+      clients={clients}
+      initialClient={initialClient}
+      lockClient={lockClient}
+      compact={compact}
+    />
+  );
+}

--- a/components/mcp/client-picker-server.tsx
+++ b/components/mcp/client-picker-server.tsx
@@ -1,4 +1,4 @@
-import { getMcpClients, type McpClient } from '@/lib/mcp-clients';
+import { getMcpClients, getMcpLaunchers, type McpClient, type McpLauncher } from '@/lib/mcp-clients';
 import { McpClientPicker } from './client-picker';
 
 type Props = {
@@ -10,6 +10,7 @@ type Props = {
 
 export function McpClientPickerServer({ initialClient, lockClient, compact, only }: Props) {
   let clients: McpClient[] = getMcpClients();
+  const launchers: McpLauncher[] = getMcpLaunchers();
   if (only && only.length > 0) {
     const set = new Set(only);
     clients = clients.filter((c) => set.has(c.id));
@@ -20,6 +21,7 @@ export function McpClientPickerServer({ initialClient, lockClient, compact, only
       initialClient={initialClient}
       lockClient={lockClient}
       compact={compact}
+      launchers={launchers}
     />
   );
 }

--- a/components/mcp/client-picker.tsx
+++ b/components/mcp/client-picker.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { McpClient } from '@/lib/mcp-clients';
+import { renderInstallSnippet } from '@/lib/mcp-clients';
+
+type Props = {
+  clients: McpClient[];
+  initialClient?: string;
+  lockClient?: boolean;
+  compact?: boolean;
+};
+
+export function McpClientPicker({ clients, initialClient, lockClient, compact }: Props) {
+  const ordered = useMemo(() => {
+    if (!initialClient) return clients;
+    const first = clients.find((c) => c.id === initialClient);
+    if (!first) return clients;
+    return [first, ...clients.filter((c) => c.id !== first.id)];
+  }, [clients, initialClient]);
+
+  const [clientId, setClientId] = useState(initialClient ?? ordered[0]?.id);
+  const active = ordered.find((c) => c.id === clientId) ?? ordered[0];
+  const [scopeId, setScopeId] = useState(active?.scopes[0]?.id ?? 'user');
+
+  if (!active) return null;
+
+  const currentScope = active.scopes.find((s) => s.id === scopeId) ?? active.scopes[0];
+  const snippet = renderInstallSnippet(active, currentScope.id);
+  const copyLabel = snippet.language === 'bash' ? 'Copy command' : 'Copy snippet';
+
+  return (
+    <div
+      className={`my-6 grid gap-4 rounded-xl border border-border bg-card p-4 ${
+        compact ? '' : 'md:grid-cols-[200px,1fr]'
+      }`}
+    >
+      {!lockClient && !compact && (
+        <nav aria-label="MCP clients" className="flex flex-col gap-1">
+          {ordered.map((c) => (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => {
+                setClientId(c.id);
+                const next = clients.find((x) => x.id === c.id);
+                setScopeId(next?.scopes[0]?.id ?? 'user');
+              }}
+              className={`flex items-center justify-between rounded-md px-3 py-2 text-left text-sm ${
+                c.id === active.id
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-muted'
+              }`}
+              aria-current={c.id === active.id}
+            >
+              <span>{c.name}</span>
+              <span className="text-xs uppercase opacity-60">{c.category}</span>
+            </button>
+          ))}
+        </nav>
+      )}
+
+      <div className="min-w-0">
+        {compact && !lockClient && (
+          <label className="mb-3 block text-xs text-muted-foreground">
+            <span className="sr-only">Client</span>
+            <select
+              value={active.id}
+              onChange={(e) => {
+                setClientId(e.target.value);
+                const next = clients.find((x) => x.id === e.target.value);
+                setScopeId(next?.scopes[0]?.id ?? 'user');
+              }}
+              className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
+            >
+              {ordered.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        )}
+
+        {active.scopes.length > 1 && (
+          <div className="mb-3 flex flex-wrap gap-2" role="tablist" aria-label="Install scope">
+            {active.scopes.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                role="tab"
+                aria-selected={s.id === currentScope.id}
+                onClick={() => setScopeId(s.id)}
+                className={`rounded-md border px-2 py-1 text-xs ${
+                  s.id === currentScope.id
+                    ? 'border-primary bg-primary/10 text-primary'
+                    : 'border-border text-muted-foreground hover:bg-muted'
+                }`}
+              >
+                {s.label}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {snippet.path && (
+          <p className="mb-1 text-xs text-muted-foreground">
+            <span className="font-medium">Path:</span> <code>{snippet.path}</code>
+          </p>
+        )}
+
+        <div className="relative">
+          <pre className="max-h-80 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
+            <code>{snippet.content}</code>
+          </pre>
+          <CopyButton label={copyLabel} value={snippet.content} />
+        </div>
+
+        <p className="mt-3 text-xs text-muted-foreground">
+          <span className="font-medium text-foreground">Verify:</span> {active.verify}
+        </p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Upstream docs:{' '}
+          <a href={active.sourceUrl} className="underline underline-offset-2" rel="noreferrer noopener" target="_blank">
+            {active.sourceUrl}
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CopyButton({ label, value }: { label: string; value: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(value);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        } catch {
+          /* ignore */
+        }
+      }}
+      className="absolute right-2 top-2 rounded-md border border-border bg-background px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+    >
+      {copied ? 'Copied' : label}
+    </button>
+  );
+}

--- a/components/mcp/client-picker.tsx
+++ b/components/mcp/client-picker.tsx
@@ -1,17 +1,26 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import type { McpClient } from '@/lib/mcp-clients';
+import { useEffect, useMemo, useState } from 'react';
+import { Callout } from 'fumadocs-ui/components/callout';
+import { Card, Cards } from 'fumadocs-ui/components/card';
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
+import { Tabs, TabsList, TabsTrigger } from 'fumadocs-ui/components/ui/tabs';
+import type { McpClient, McpLauncher, McpLauncherId } from '@/lib/mcp-clients';
 import { renderInstallSnippet } from '@/lib/mcp-clients';
 
 type Props = {
   clients: McpClient[];
+  launchers: McpLauncher[];
   initialClient?: string;
   lockClient?: boolean;
   compact?: boolean;
 };
 
-export function McpClientPicker({ clients, initialClient, lockClient, compact }: Props) {
+const CLIENT_KEY = 'vaner.mcp.client';
+const SCOPE_KEY = 'vaner.mcp.scope';
+const LAUNCHER_KEY = 'vaner.mcp.launcher';
+
+export function McpClientPicker({ clients, launchers, initialClient, lockClient, compact }: Props) {
   const ordered = useMemo(() => {
     if (!initialClient) return clients;
     const first = clients.find((c) => c.id === initialClient);
@@ -22,11 +31,40 @@ export function McpClientPicker({ clients, initialClient, lockClient, compact }:
   const [clientId, setClientId] = useState(initialClient ?? ordered[0]?.id);
   const active = ordered.find((c) => c.id === clientId) ?? ordered[0];
   const [scopeId, setScopeId] = useState(active?.scopes[0]?.id ?? 'user');
+  const [launcherId, setLauncherId] = useState<McpLauncherId>('uvx');
 
   if (!active) return null;
 
+  useEffect(() => {
+    if (lockClient || typeof window === 'undefined') return;
+    const storedClient = window.localStorage.getItem(CLIENT_KEY);
+    const storedScope = window.localStorage.getItem(SCOPE_KEY);
+    const storedLauncher = window.localStorage.getItem(LAUNCHER_KEY);
+    if (storedClient && ordered.some((client) => client.id === storedClient)) {
+      setClientId(storedClient);
+    }
+    if (storedScope) setScopeId(storedScope);
+    if (storedLauncher === 'uvx' || storedLauncher === 'path') {
+      setLauncherId(storedLauncher);
+    }
+  }, [lockClient, ordered]);
+
+  useEffect(() => {
+    const selectedClient = ordered.find((client) => client.id === clientId) ?? ordered[0];
+    if (!selectedClient.scopes.some((scope) => scope.id === scopeId)) {
+      setScopeId(selectedClient.scopes[0]?.id ?? 'user');
+    }
+  }, [clientId, ordered, scopeId]);
+
+  useEffect(() => {
+    if (lockClient || typeof window === 'undefined') return;
+    window.localStorage.setItem(CLIENT_KEY, clientId ?? '');
+    window.localStorage.setItem(SCOPE_KEY, scopeId);
+    window.localStorage.setItem(LAUNCHER_KEY, launcherId);
+  }, [clientId, scopeId, launcherId, lockClient]);
+
   const currentScope = active.scopes.find((s) => s.id === scopeId) ?? active.scopes[0];
-  const snippet = renderInstallSnippet(active, currentScope.id);
+  const snippet = renderInstallSnippet(active, currentScope.id, launcherId);
   const copyLabel = snippet.language === 'bash' ? 'Copy command' : 'Copy snippet';
 
   return (
@@ -83,24 +121,34 @@ export function McpClientPicker({ clients, initialClient, lockClient, compact }:
         )}
 
         {active.scopes.length > 1 && (
-          <div className="mb-3 flex flex-wrap gap-2" role="tablist" aria-label="Install scope">
-            {active.scopes.map((s) => (
-              <button
-                key={s.id}
-                type="button"
-                role="tab"
-                aria-selected={s.id === currentScope.id}
-                onClick={() => setScopeId(s.id)}
-                className={`rounded-md border px-2 py-1 text-xs ${
-                  s.id === currentScope.id
-                    ? 'border-primary bg-primary/10 text-primary'
-                    : 'border-border text-muted-foreground hover:bg-muted'
-                }`}
-              >
-                {s.label}
-              </button>
-            ))}
-          </div>
+          <Tabs value={currentScope.id} onValueChange={setScopeId} className="mb-3">
+            <TabsList>
+              {active.scopes.map((scope) => (
+                <TabsTrigger key={scope.id} value={scope.id}>
+                  {scope.label}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        )}
+
+        {launchers.length > 0 && (
+          <Tabs value={launcherId} onValueChange={(value) => setLauncherId(value as McpLauncherId)} className="mb-3">
+            <TabsList>
+              {launchers.map((launcher) => (
+                <TabsTrigger key={launcher.id} value={launcher.id}>
+                  {launcher.id === 'uvx' ? 'Run via uvx (recommended)' : 'Use installed vaner on PATH'}
+                </TabsTrigger>
+              ))}
+            </TabsList>
+          </Tabs>
+        )}
+
+        {snippet.missingScopePath && (
+          <Callout type="warning" className="mb-3" title="Scope path not defined for this client">
+            This scope does not have a configured target path in the client manifest. Pick another scope or update
+            `content/mcp/clients.json`.
+          </Callout>
         )}
 
         {snippet.path && (
@@ -110,21 +158,16 @@ export function McpClientPicker({ clients, initialClient, lockClient, compact }:
         )}
 
         <div className="relative">
-          <pre className="max-h-80 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
-            <code>{snippet.content}</code>
-          </pre>
+          <DynamicCodeBlock lang={snippet.language} code={snippet.content} />
           <CopyButton label={copyLabel} value={snippet.content} />
         </div>
 
-        <p className="mt-3 text-xs text-muted-foreground">
-          <span className="font-medium text-foreground">Verify:</span> {active.verify}
-        </p>
-        <p className="mt-1 text-xs text-muted-foreground">
-          Upstream docs:{' '}
-          <a href={active.sourceUrl} className="underline underline-offset-2" rel="noreferrer noopener" target="_blank">
+        <Cards className="mt-3">
+          <Card title="Verify">{active.verify}</Card>
+          <Card title="Upstream docs" href={active.sourceUrl} external>
             {active.sourceUrl}
-          </a>
-        </p>
+          </Card>
+        </Cards>
       </div>
     </div>
   );

--- a/components/mcp/compute-budget.tsx
+++ b/components/mcp/compute-budget.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type ComputePreset = {
+  id: 'background' | 'balanced' | 'dedicated';
+  label: string;
+  description: string;
+  snippet: string;
+};
+
+const PRESETS: ComputePreset[] = [
+  {
+    id: 'background',
+    label: 'Background',
+    description: 'Safe default. Only ponders when your machine is idle; caps CPU and GPU.',
+    snippet:
+      '[compute]\nidle_only = true\ncpu_fraction = 0.2\ngpu_memory_fraction = 0.5\nexploration_concurrency = 2\nmax_parallel_precompute = 1\nmax_cycle_seconds = 300\n',
+  },
+  {
+    id: 'balanced',
+    label: 'Balanced',
+    description: 'Runs even while you work, but bounded so it does not dominate the machine.',
+    snippet:
+      '[compute]\nidle_only = false\ncpu_fraction = 0.4\ngpu_memory_fraction = 0.6\nexploration_concurrency = 4\nmax_parallel_precompute = 2\nmax_cycle_seconds = 300\n',
+  },
+  {
+    id: 'dedicated',
+    label: 'Dedicated',
+    description: 'Maxes out the local machine — best for dedicated hardware or overnight runs.',
+    snippet:
+      '[compute]\nidle_only = false\ncpu_fraction = 0.8\ngpu_memory_fraction = 0.9\nexploration_concurrency = 8\nmax_parallel_precompute = 4\nmax_cycle_seconds = 600\n',
+  },
+];
+
+type Props = {
+  initialPreset?: ComputePreset['id'];
+  compact?: boolean;
+};
+
+export function ComputeBudget({ initialPreset, compact }: Props) {
+  const [presetId, setPresetId] = useState<ComputePreset['id']>(initialPreset ?? 'background');
+  const [minutes, setMinutes] = useState<number | ''>('');
+  const [copied, setCopied] = useState(false);
+
+  const active = useMemo(() => PRESETS.find((p) => p.id === presetId) ?? PRESETS[0], [presetId]);
+  const renderedSnippet = useMemo(() => {
+    if (minutes === '' || Number(minutes) <= 0) return active.snippet;
+    return `${active.snippet.trimEnd()}\nmax_session_minutes = ${Number(minutes)}\n`;
+  }, [active, minutes]);
+
+  return (
+    <div className={`my-6 rounded-xl border border-border bg-card p-4 ${compact ? '' : ''}`}>
+      <div className="mb-3 flex flex-wrap gap-2">
+        {PRESETS.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            onClick={() => setPresetId(p.id)}
+            className={`rounded-md border px-2 py-1 text-xs ${
+              p.id === active.id
+                ? 'border-primary bg-primary/10 text-primary'
+                : 'border-border text-muted-foreground hover:bg-muted'
+            }`}
+            aria-pressed={p.id === active.id}
+          >
+            {p.label}
+          </button>
+        ))}
+      </div>
+      <p className="mb-3 text-xs text-muted-foreground">{active.description}</p>
+
+      <label className="mb-3 block text-xs text-muted-foreground">
+        <span className="mb-1 block font-medium text-foreground">Ponder session cap (minutes)</span>
+        <input
+          type="number"
+          min={0}
+          step={5}
+          placeholder="leave empty for unbounded"
+          value={minutes}
+          onChange={(e) => {
+            const v = e.target.value;
+            setMinutes(v === '' ? '' : Math.max(0, Number(v)));
+          }}
+          className="w-full rounded-md border border-border bg-background px-2 py-1 text-sm"
+        />
+      </label>
+
+      <div className="relative">
+        <pre className="max-h-60 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
+          <code>{renderedSnippet}</code>
+        </pre>
+        <button
+          type="button"
+          onClick={async () => {
+            try {
+              await navigator.clipboard.writeText(renderedSnippet);
+              setCopied(true);
+              setTimeout(() => setCopied(false), 1500);
+            } catch {
+              /* ignore */
+            }
+          }}
+          className="absolute right-2 top-2 rounded-md border border-border bg-background px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+        >
+          {copied ? 'Copied' : 'Copy TOML'}
+        </button>
+      </div>
+
+      <p className="mt-3 text-xs text-muted-foreground">
+        `max_cycle_seconds` bounds a single ponder cycle; `max_session_minutes` bounds a whole
+        `vaner daemon` run. Both are safe to leave at their defaults.
+      </p>
+    </div>
+  );
+}

--- a/components/mcp/compute-budget.tsx
+++ b/components/mcp/compute-budget.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { Callout } from 'fumadocs-ui/components/callout';
+import { DynamicCodeBlock } from 'fumadocs-ui/components/dynamic-codeblock';
+import { Tabs, TabsList, TabsTrigger } from 'fumadocs-ui/components/ui/tabs';
 
 type ComputePreset = {
   id: 'background' | 'balanced' | 'dedicated';
@@ -51,23 +54,15 @@ export function ComputeBudget({ initialPreset, compact }: Props) {
 
   return (
     <div className={`my-6 rounded-xl border border-border bg-card p-4 ${compact ? '' : ''}`}>
-      <div className="mb-3 flex flex-wrap gap-2">
-        {PRESETS.map((p) => (
-          <button
-            key={p.id}
-            type="button"
-            onClick={() => setPresetId(p.id)}
-            className={`rounded-md border px-2 py-1 text-xs ${
-              p.id === active.id
-                ? 'border-primary bg-primary/10 text-primary'
-                : 'border-border text-muted-foreground hover:bg-muted'
-            }`}
-            aria-pressed={p.id === active.id}
-          >
-            {p.label}
-          </button>
-        ))}
-      </div>
+      <Tabs value={active.id} onValueChange={(value) => setPresetId(value as ComputePreset['id'])} className="mb-3">
+        <TabsList>
+          {PRESETS.map((preset) => (
+            <TabsTrigger key={preset.id} value={preset.id}>
+              {preset.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+      </Tabs>
       <p className="mb-3 text-xs text-muted-foreground">{active.description}</p>
 
       <label className="mb-3 block text-xs text-muted-foreground">
@@ -87,9 +82,7 @@ export function ComputeBudget({ initialPreset, compact }: Props) {
       </label>
 
       <div className="relative">
-        <pre className="max-h-60 overflow-auto rounded-md border border-border bg-muted/40 p-3 text-xs">
-          <code>{renderedSnippet}</code>
-        </pre>
+        <DynamicCodeBlock lang="toml" code={renderedSnippet} />
         <button
           type="button"
           onClick={async () => {
@@ -107,10 +100,10 @@ export function ComputeBudget({ initialPreset, compact }: Props) {
         </button>
       </div>
 
-      <p className="mt-3 text-xs text-muted-foreground">
-        `max_cycle_seconds` bounds a single ponder cycle; `max_session_minutes` bounds a whole
-        `vaner daemon` run. Both are safe to leave at their defaults.
-      </p>
+      <Callout type="info" className="mt-3">
+        <code>max_cycle_seconds</code> bounds a single ponder cycle. <code>max_session_minutes</code> bounds a
+        continuous <code>vaner daemon</code> run.
+      </Callout>
     </div>
   );
 }

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -1,74 +1,88 @@
 ---
 title: Getting Started
-description: Install Vaner, initialize a workspace, and run your first query.
+description: Install Vaner, pick a backend, and connect your AI client over MCP.
 ---
 
-## Install
+## 1. Install
 
 ```bash
-curl -fsSL https://vaner.ai/install.sh | bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
 ```
 
-The installer supports Linux/macOS. It auto-detects `uv` or `pipx`, asks before
-installing missing prerequisites (Python 3.11+, `uv`/`pipx`), and then installs
-`vaner`.
-Windows one-liner support is planned once a Windows install asset is available.
+The installer works on Linux and macOS. It auto-detects `uv` or `pipx`, asks
+before installing missing prerequisites (Python 3.11+, `uv`/`pipx`), and
+installs `vaner[mcp]` so the MCP server is ready out of the box. Pass
+`--no-mcp` to skip the MCP extra.
 
-### Review script before running
-
-- Canonical source (current rollout PR): [github.com/Borgels/vaner/pull/88/files](https://github.com/Borgels/vaner/pull/88/files)
-- Hosted URL after deploy: `https://vaner.ai/install.sh`
+### Non-interactive install (CI, Dockerfiles)
 
 ```bash
-curl -s https://raw.githubusercontent.com/Borgels/vaner/feat/install-oneliner/scripts/install.sh
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh \
+  | bash -s -- --yes \
+      --backend-preset openai \
+      --backend-model gpt-4o-mini \
+      --backend-api-key-env OPENAI_API_KEY \
+      --compute-preset background \
+      --max-session-minutes 30
 ```
 
-### Installer options
+### Environment variable mirrors
+
+- `VANER_YES=1`, `VANER_DRY_RUN=1`, `VANER_VERIFY=1`
+- `VANER_BACKEND=uv|pipx`, `VANER_VERSION=<version>`
+- `VANER_NO_MODIFY_PATH=1`, `VANER_VERBOSE=1`
+- `VANER_NO_MCP=1` (skip the `[mcp]` extra)
+- `VANER_BACKEND_PRESET=<id>`, `VANER_BACKEND_URL`, `VANER_BACKEND_MODEL`, `VANER_BACKEND_API_KEY_ENV`
+- `VANER_COMPUTE_PRESET=<id>`, `VANER_MAX_SESSION_MINUTES=<minutes>`
+
+Installer source for review: [scripts/install.sh](https://github.com/Borgels/vaner/blob/main/scripts/install.sh).
+
+### From source
 
 ```bash
-# Non-interactive (CI)
-curl -fsSL https://vaner.ai/install.sh | bash -s -- --yes
-
-# Force backend
-curl -fsSL https://vaner.ai/install.sh | bash -s -- --backend pipx
-
-# Dry-run / verify
-curl -fsSL https://vaner.ai/install.sh | bash -s -- --dry-run
-curl -fsSL https://vaner.ai/install.sh | bash -s -- --verify
+git clone https://github.com/Borgels/vaner.git
+cd vaner
+pip install '.[mcp]'
 ```
 
-Environment variable mirrors:
-
-- `VANER_YES=1`
-- `VANER_DRY_RUN=1`
-- `VANER_VERIFY=1`
-- `VANER_BACKEND=uv|pipx`
-- `VANER_VERSION=<version>`
-- `VANER_NO_MODIFY_PATH=1`
-- `VANER_VERBOSE=1`
-
-### From source / contributors
+## 2. Initialize the repo
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e ".[dev]"
+vaner init --path .
 ```
 
-## Initialize and run
+`vaner init` picks up the installer's backend / compute choices (if any) and
+writes `~/.vaner/config.toml`. It's idempotent — rerunning it leaves your
+existing config alone unless you pass `--force`.
+
+## 3. Connect your AI client
+
+See [Connect your client](/mcp) for the picker. The short version:
 
 ```bash
-vaner init --profile minimal --path .
+# Claude Code
+claude mcp add --transport stdio --scope user vaner -- vaner mcp --path .
+
+# Codex CLI
+codex mcp add vaner -- vaner mcp --path .
+```
+
+For Cursor, VS Code, Zed, Windsurf, Continue, Claude Desktop, Cline, and Roo,
+use the [per-client guides](/integrations/tools/claude-code-mcp).
+
+## 4. Run it
+
+```bash
 vaner daemon start --no-once --path .
-vaner query "where is auth enforced?" --path .
+vaner query "where is auth enforced?" --explain --path .
 vaner inspect --last --path .
 ```
 
-## Choose an integration mode
+## Choose an integration mode (optional)
 
-- **Proxy mode** (`/v1/chat/completions`): best when tools expect OpenAI-compatible APIs.
-- **MCP mode**: best when your IDE supports MCP natively.
-- **Context-only mode** (`/v1/context`): best when your agent handles model routing and only needs context.
-- **Python SDK**: best for scripts and custom automation.
+Most users stay on MCP. If your tool needs another shape:
 
-See [Integrations](/integrations) for details.
+- **[MCP mode](/integrations/mcp)** (default): native IDE integration.
+- **[Proxy mode](/integrations/proxy)**: OpenAI-compatible `/v1/chat/completions`.
+- **[Context-only mode](/integrations/context-only)**: `/v1/context` for agents.
+- **[Python SDK](/integrations/python-sdk)**: scripts and custom tooling.

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -17,13 +17,13 @@ installs `vaner[mcp]` so the MCP server is ready out of the box. Pass
 ### Non-interactive install (CI, Dockerfiles)
 
 ```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh \
-  | bash -s -- --yes \
-      --backend-preset openai \
-      --backend-model gpt-4o-mini \
-      --backend-api-key-env OPENAI_API_KEY \
-      --compute-preset background \
-      --max-session-minutes 30
+VANER_YES=1 \
+VANER_BACKEND_PRESET=openai \
+VANER_BACKEND_MODEL=gpt-4o-mini \
+VANER_BACKEND_API_KEY_ENV=OPENAI_API_KEY \
+VANER_COMPUTE_PRESET=background \
+VANER_MAX_SESSION_MINUTES=30 \
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
 ```
 
 ### Environment variable mirrors

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -7,14 +7,6 @@ Vaner is a **local-first predictive context engine** for AI coding workflows.
 
 Think of it like a chess engine for context: during idle time, Vaner predicts likely next prompts, prepares useful context branches, and then serves the best package quickly when the real prompt arrives.
 
-<iframe
-  src="https://ghbtns.com/github-btn.html?user=Borgels&repo=Vaner&type=star&count=true&size=large"
-  title="Star Vaner on GitHub"
-  width="170"
-  height="30"
-  style={{ border: 0, overflow: "hidden" }}
-/>
-
 ## What Vaner does
 
 - Runs a background **ponder loop** to pre-build likely context.
@@ -32,6 +24,7 @@ Vaner is successful when it improves one or more of:
 ## Start here
 
 - New users: [Getting started](/getting-started)
+- Wire up your AI client over MCP: [Connect your client](/mcp)
 - Concepts and terminology: [Concepts](/concepts)
 - Setup and tuning: [Configuration](/configuration)
 - Integration modes: [Integrations](/integrations)

--- a/content/docs/integrations/mcp.mdx
+++ b/content/docs/integrations/mcp.mdx
@@ -1,12 +1,46 @@
 ---
 title: MCP Mode
-description: Use Vaner with IDEs and agents that support MCP.
+description: Conceptual overview of Vaner's MCP integration — what tools it exposes and how clients connect.
 ---
 
-Start MCP server:
+Vaner ships an [MCP](https://modelcontextprotocol.io/) server so any
+MCP-aware IDE or agent (Claude Code, Cursor, VS Code Copilot, Codex CLI,
+Windsurf, Zed, Continue, Cline, Roo, Claude Desktop, …) can pull
+scenario-ranked context without Vaner being in the model path.
+
+## Start the server
 
 ```bash
 vaner mcp --path .
 ```
 
-Use this mode when your IDE already orchestrates backend model calls and only needs Vaner-provided context.
+The server speaks stdio by default. Clients invoke `vaner mcp --path .` as a
+subprocess and communicate over their own stdin/stdout.
+
+## Tools exposed
+
+| Tool | Purpose |
+| --- | --- |
+| `list_scenarios` | Scenarios Vaner has precomputed for this repo. |
+| `query` | Ask a natural-language question; receive a ranked context package. |
+| `inspect` | Inspect the last served package (files, reasons, token budget). |
+| `explain` | Explanation of the scenario Vaner picked. |
+| `refresh` | Force a new ponder cycle over a file or subtree. |
+
+All tools are scoped to the `--path` Vaner was started with.
+
+## Want to wire it up?
+
+- [Connect your client](/mcp) — picker for all supported clients.
+- [Per-client guides](/integrations/tools/claude-code-mcp) — one page per tool.
+- [Backends](/backends) — pick the LLM Vaner ponders with.
+
+## When to use MCP vs other modes
+
+- **MCP mode** (this page): your IDE already orchestrates model calls and only
+  needs Vaner-provided context. Lowest coupling; recommended default.
+- **[Proxy mode](/integrations/proxy)**: tools that only speak the OpenAI
+  `/v1/chat/completions` shape.
+- **[Context-only mode](/integrations/context-only)**: frameworks that call
+  `/v1/context` directly.
+- **[Python SDK](/integrations/python-sdk)**: custom scripts.

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -2,8 +2,9 @@
   "title": "Integrations",
   "pages": [
     "index",
-    "proxy",
     "mcp",
+    "tools",
+    "proxy",
     "context-only",
     "python-sdk",
     "docker"

--- a/content/docs/integrations/tools/claude-code-mcp.mdx
+++ b/content/docs/integrations/tools/claude-code-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Claude Code + Vaner (MCP)
+description: Connect Claude Code to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Claude Code
+
+<McpClientPicker initialClient="claude-code" lockClient />
+
+## Verify
+
+Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.
+
+If `Claude Code` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Scope `/tmp` work to your repo: Claude Code hits Vaner for `list_scenarios` before running its own tools.
+- Switch between `user` / `project` / `local` scope without editing JSON by hand.
+- Tight loop with `claude --resume` — Vaner keeps the ponder cache between sessions.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.anthropic.com/en/docs/claude-code/mcp](https://docs.anthropic.com/en/docs/claude-code/mcp).

--- a/content/docs/integrations/tools/claude-desktop-mcp.mdx
+++ b/content/docs/integrations/tools/claude-desktop-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Claude Desktop + Vaner (MCP)
+description: Connect Claude Desktop to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Claude Desktop](https://modelcontextprotocol.io/quickstart/user) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Claude Desktop
+
+<McpClientPicker initialClient="claude-desktop" lockClient />
+
+## Verify
+
+Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.
+
+If `Claude Desktop` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Chat with Claude Desktop about a repo without SSH-ing anywhere: Vaner mounts it via MCP.
+- Hammer menu lists every Vaner scenario tool with inline descriptions.
+- Toggle off anytime by removing the `vaner` entry from `claude_desktop_config.json`.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://modelcontextprotocol.io/quickstart/user](https://modelcontextprotocol.io/quickstart/user).

--- a/content/docs/integrations/tools/cline-mcp.mdx
+++ b/content/docs/integrations/tools/cline-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Cline + Vaner (MCP)
+description: Connect Cline to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Cline](https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Cline
+
+<McpClientPicker initialClient="cline" lockClient />
+
+## Verify
+
+Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.
+
+If `Cline` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Cline can auto-consult Vaner between autonomous steps to stay grounded in repo reality.
+- Toggle the server on/off from Cline’s MCP panel without restarting VS Code.
+- Feed Vaner’s ranked context into Cline’s planner for multi-file edits.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers](https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers).

--- a/content/docs/integrations/tools/cline-mcp.mdx
+++ b/content/docs/integrations/tools/cline-mcp.mdx
@@ -3,7 +3,7 @@ title: Cline + Vaner (MCP)
 description: Connect Cline to Vaner over MCP for predictive, repo-grounded context.
 ---
 
-[Cline](https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers) supports the
+[Cline](https://docs.cline.bot/mcp/adding-and-configuring-servers) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
 Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
@@ -39,4 +39,4 @@ missing backend API key — confirm with `vaner config show`.
 
 - The full [Connect your client](/mcp) guide.
 - [Backends](/backends) for picking the model Vaner ponders with.
-- Upstream docs: [https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers](https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers).
+- Upstream docs: [https://docs.cline.bot/mcp/adding-and-configuring-servers](https://docs.cline.bot/mcp/adding-and-configuring-servers).

--- a/content/docs/integrations/tools/codex-cli-mcp.mdx
+++ b/content/docs/integrations/tools/codex-cli-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Codex CLI + Vaner (MCP)
+description: Connect Codex CLI to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Codex CLI](https://github.com/openai/codex) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Codex CLI
+
+<McpClientPicker initialClient="codex-cli" lockClient />
+
+## Verify
+
+Run `codex mcp list` — `vaner` should appear with status `running`.
+
+If `Codex CLI` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Feed Vaner context to Codex CLI sessions: `codex exec "refactor X"` will now consult `vaner.query` first.
+- Pin a per-repo backend in `~/.codex/config.toml` alongside the Vaner entry.
+- Pair with `vaner daemon start` to keep ponder warm between CLI invocations.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://github.com/openai/codex](https://github.com/openai/codex).

--- a/content/docs/integrations/tools/continue-mcp.mdx
+++ b/content/docs/integrations/tools/continue-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Continue + Vaner (MCP)
+description: Connect Continue to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Continue](https://docs.continue.dev/customize/deep-dives/mcp) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Continue
+
+<McpClientPicker initialClient="continue" lockClient />
+
+## Verify
+
+Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.
+
+If `Continue` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Continue’s agent mode calls `vaner.list_scenarios` between steps for grounded plans.
+- Ship the YAML in `.continue/` so teammates inherit the integration.
+- Combine with Continue’s code lenses to open `vaner.inspect` output inline.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.continue.dev/customize/deep-dives/mcp](https://docs.continue.dev/customize/deep-dives/mcp).

--- a/content/docs/integrations/tools/cursor-mcp.mdx
+++ b/content/docs/integrations/tools/cursor-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Cursor + Vaner (MCP)
+description: Connect Cursor to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Cursor](https://docs.cursor.com/en/context/mcp) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Cursor
+
+<McpClientPicker initialClient="cursor" lockClient />
+
+## Verify
+
+Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.
+
+If `Cursor` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Composer auto-calls `vaner.query` for "where is X?" prompts instead of grepping from scratch.
+- Project-scoped config keeps Vaner active only in the repos you want.
+- Agent mode uses `vaner.explain` to justify its file picks in the chat sidebar.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.cursor.com/en/context/mcp](https://docs.cursor.com/en/context/mcp).

--- a/content/docs/integrations/tools/meta.json
+++ b/content/docs/integrations/tools/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Per-client guides",
+  "pages": [
+    "claude-code-mcp",
+    "cursor-mcp",
+    "vscode-copilot-mcp",
+    "codex-cli-mcp",
+    "windsurf-mcp",
+    "continue-mcp",
+    "zed-mcp",
+    "claude-desktop-mcp",
+    "cline-mcp",
+    "roo-mcp"
+  ]
+}

--- a/content/docs/integrations/tools/roo-mcp.mdx
+++ b/content/docs/integrations/tools/roo-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Roo Code + Vaner (MCP)
+description: Connect Roo Code to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Roo Code](https://docs.roocode.com/features/mcp) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Roo Code
+
+<McpClientPicker initialClient="roo" lockClient />
+
+## Verify
+
+Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.
+
+If `Roo Code` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Roo Code’s agent mode calls `vaner.query` before writing diffs.
+- Project-level `.roo/mcp.json` so repos opt in explicitly.
+- Works with Roo’s orchestration to break large changes into Vaner-informed steps.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.roocode.com/features/mcp](https://docs.roocode.com/features/mcp).

--- a/content/docs/integrations/tools/roo-mcp.mdx
+++ b/content/docs/integrations/tools/roo-mcp.mdx
@@ -3,7 +3,7 @@ title: Roo Code + Vaner (MCP)
 description: Connect Roo Code to Vaner over MCP for predictive, repo-grounded context.
 ---
 
-[Roo Code](https://docs.roocode.com/features/mcp) supports the
+[Roo Code](https://docs.roocode.com/features/mcp/using-mcp-in-roo) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
 Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
@@ -39,4 +39,4 @@ missing backend API key — confirm with `vaner config show`.
 
 - The full [Connect your client](/mcp) guide.
 - [Backends](/backends) for picking the model Vaner ponders with.
-- Upstream docs: [https://docs.roocode.com/features/mcp](https://docs.roocode.com/features/mcp).
+- Upstream docs: [https://docs.roocode.com/features/mcp/using-mcp-in-roo](https://docs.roocode.com/features/mcp/using-mcp-in-roo).

--- a/content/docs/integrations/tools/vscode-copilot-mcp.mdx
+++ b/content/docs/integrations/tools/vscode-copilot-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: VS Code (Copilot) + Vaner (MCP)
+description: Connect VS Code (Copilot) to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[VS Code (Copilot)](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect VS Code (Copilot)
+
+<McpClientPicker initialClient="vscode-copilot" lockClient />
+
+## Verify
+
+Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.
+
+If `VS Code (Copilot)` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Use `@vaner` in Copilot Chat to pull in scenario-ranked context before generating a diff.
+- Share the workspace config via `.vscode/mcp.json` so teammates pick it up on clone.
+- Combine with GitHub Copilot Workspace for repo-wide refactors.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://code.visualstudio.com/docs/copilot/chat/mcp-servers](https://code.visualstudio.com/docs/copilot/chat/mcp-servers).

--- a/content/docs/integrations/tools/windsurf-mcp.mdx
+++ b/content/docs/integrations/tools/windsurf-mcp.mdx
@@ -3,7 +3,7 @@ title: Windsurf + Vaner (MCP)
 description: Connect Windsurf to Vaner over MCP for predictive, repo-grounded context.
 ---
 
-[Windsurf](https://docs.windsurf.com/windsurf/mcp) supports the
+[Windsurf](https://docs.windsurf.com/windsurf/cascade/mcp) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
 Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
@@ -39,4 +39,4 @@ missing backend API key — confirm with `vaner config show`.
 
 - The full [Connect your client](/mcp) guide.
 - [Backends](/backends) for picking the model Vaner ponders with.
-- Upstream docs: [https://docs.windsurf.com/windsurf/mcp](https://docs.windsurf.com/windsurf/mcp).
+- Upstream docs: [https://docs.windsurf.com/windsurf/cascade/mcp](https://docs.windsurf.com/windsurf/cascade/mcp).

--- a/content/docs/integrations/tools/windsurf-mcp.mdx
+++ b/content/docs/integrations/tools/windsurf-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Windsurf + Vaner (MCP)
+description: Connect Windsurf to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Windsurf](https://docs.windsurf.com/windsurf/mcp) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Windsurf
+
+<McpClientPicker initialClient="windsurf" lockClient />
+
+## Verify
+
+Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.
+
+If `Windsurf` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Cascade pulls Vaner scenarios before drafting a plan, reducing thrash on large repos.
+- Works alongside Windsurf’s built-in memory — Vaner supplies the structural context.
+- Switch repos without restarting Windsurf; Vaner scopes itself to `--path`.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://docs.windsurf.com/windsurf/mcp](https://docs.windsurf.com/windsurf/mcp).

--- a/content/docs/integrations/tools/zed-mcp.mdx
+++ b/content/docs/integrations/tools/zed-mcp.mdx
@@ -1,0 +1,42 @@
+---
+title: Zed + Vaner (MCP)
+description: Connect Zed to Vaner over MCP for predictive, repo-grounded context.
+---
+
+[Zed](https://zed.dev/docs/assistant/model-context-protocol) supports the
+[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
+Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
+agent before every prompt.
+
+## Install
+
+If you haven't installed Vaner yet:
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+vaner init --path .
+```
+
+## Connect Zed
+
+<McpClientPicker initialClient="zed" lockClient />
+
+## Verify
+
+Restart Zed. Open the Assistant panel; `vaner` should appear under Context Servers.
+
+If `Zed` reports the server as failed, run `vaner mcp --path .`
+manually in a terminal and read the error. The most common failure is a
+missing backend API key — confirm with `vaner config show`.
+
+## What this unlocks
+
+- Zed Assistant can route context requests through Vaner instead of its built-in scanner.
+- Low-latency local loop: Zed + Ollama + Vaner all stay on your machine.
+- One `settings.json` block per user, no per-project config required.
+
+## See also
+
+- The full [Connect your client](/mcp) guide.
+- [Backends](/backends) for picking the model Vaner ponders with.
+- Upstream docs: [https://zed.dev/docs/assistant/model-context-protocol](https://zed.dev/docs/assistant/model-context-protocol).

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -4,13 +4,19 @@ description: Install Vaner, pick a model backend, and wire up MCP for Claude Cod
 ---
 
 Vaner exposes your repository to AI clients over the
-[Model Context Protocol](https://modelcontextprotocol.io/). Three steps:
+[Model Context Protocol](https://modelcontextprotocol.io/). Most clients can
+launch Vaner directly via `uvx`, so you can connect first and install the full
+CLI later only if you want it. Three steps:
 
-1. Install Vaner and start the MCP server.
+1. Connect your client (default: `uvx` launcher, no permanent install).
 2. Pick the model backend Vaner should ponder with.
-3. Tell your AI client where to find `vaner mcp`.
+3. Use the MCP tools from your AI client.
 
 ## 1. Install Vaner
+
+> [!NOTE]
+> The default snippets use `uvx`, which requires `uv` on your PATH. Install it
+> from [docs.astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/).
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -1,0 +1,91 @@
+---
+title: Connect your AI client
+description: Install Vaner, pick a model backend, and wire up MCP for Claude Code, Cursor, VS Code, Codex, Windsurf, Zed, Continue, Cline, Roo, and Claude Desktop.
+---
+
+Vaner exposes your repository to AI clients over the
+[Model Context Protocol](https://modelcontextprotocol.io/). Three steps:
+
+1. Install Vaner and start the MCP server.
+2. Pick the model backend Vaner should ponder with.
+3. Tell your AI client where to find `vaner mcp`.
+
+## 1. Install Vaner
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+```
+
+The installer:
+
+- Ships the `[mcp]` extra by default so `vaner mcp` works immediately.
+- Falls back to `git+https://github.com/Borgels/vaner.git` if the PyPI wheel isn't available yet.
+- Asks you to pick a backend and a compute profile (interactive TTY). Pass
+  `--yes --backend-preset <id> --compute-preset <id>` for non-interactive installs.
+
+Smoke-test the server from a terminal:
+
+```bash
+vaner init --path .
+vaner mcp --path .
+# Ctrl+C when you see "MCP server ready"
+```
+
+## 2. Pick a model backend
+
+Vaner's ponder loop needs an LLM. Local backends (Ollama, LM Studio, vLLM)
+run fully offline; hosted backends (OpenAI, Anthropic, OpenRouter) need an API
+key in an environment variable.
+
+<BackendPresetPicker />
+
+Drop the snippet into `~/.vaner/config.toml` or rerun
+`vaner init --backend-preset <id>` to let Vaner write it for you.
+
+## 3. Connect your client
+
+Pick your client, copy the snippet, restart the app, and call `list_scenarios`
+to verify.
+
+<McpClientPicker />
+
+## Optional: bound ponder time
+
+Vaner will happily ponder forever. If you want a hard cap — per cycle or per
+session — set the compute budget below:
+
+<ComputeBudget />
+
+- `max_cycle_seconds` bounds a single precompute cycle (default `300`).
+- `max_session_minutes` bounds a continuous `vaner daemon` run (default unset).
+
+Both are safe to leave at their defaults; set them if you want Vaner to stop
+pondering after, say, 30 minutes on battery.
+
+## What Vaner's MCP server exposes
+
+When your client connects to `vaner mcp`, it gets five scenario-oriented
+tools:
+
+- `list_scenarios` — scenarios Vaner has precomputed for this repo.
+- `query` — ask a natural-language question; get a ranked context package.
+- `inspect` — inspect the last served package (why these files, why this order).
+- `explain` — explanation of the scenario Vaner picked.
+- `refresh` — force a new ponder cycle over a file or subtree.
+
+See [Scenarios](/scenarios) and [Architecture](/architecture) for the full picture.
+
+## Troubleshooting
+
+- **`vaner: command not found`** — the installer didn't add pipx's bin dir.
+  Run `pipx ensurepath` or restart your shell.
+- **Client shows `vaner` as `failed`** — run `vaner mcp --path .` in a
+  terminal and read the error. The most common cause is a missing backend
+  key; confirm with `vaner config show`.
+- **`vaner mcp` exits immediately** — your client may not be sending over
+  stdio. Double-check `"type": "stdio"` in the client config.
+- **Backend not reachable** — confirm with
+  `curl -s $BASE_URL/models` (OpenAI-compatible backends expose `/v1/models`).
+
+Stuck? Open an issue with `vaner diagnose --path .` output at
+[github.com/Borgels/vaner/issues](https://github.com/Borgels/vaner/issues).

--- a/content/docs/mcp/meta.json
+++ b/content/docs/mcp/meta.json
@@ -1,0 +1,6 @@
+{
+  "title": "Connect your client",
+  "pages": [
+    "index"
+  ]
+}

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "getting-started",
+    "mcp",
     "concepts",
     "architecture",
     "configuration",

--- a/content/mcp/backends.json
+++ b/content/mcp/backends.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "./backends.schema.json",
+  "version": 1,
+  "backends": [
+    {
+      "id": "ollama",
+      "name": "Ollama (local)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:11434/v1\"\nmodel = \"llama3.2:3b\"\napi_key_env = \"\"\n",
+      "setupHint": "Install Ollama and run `ollama pull llama3.2:3b`. Ollama exposes an OpenAI-compatible endpoint on port 11434.",
+      "url": "https://ollama.com"
+    },
+    {
+      "id": "lmstudio",
+      "name": "LM Studio (local)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:1234/v1\"\nmodel = \"local-model\"\napi_key_env = \"\"\n",
+      "setupHint": "Open LM Studio → Developer → Start Server. Replace `local-model` with the identifier shown in the server log.",
+      "url": "https://lmstudio.ai"
+    },
+    {
+      "id": "vllm",
+      "name": "vLLM (self-hosted)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:8000/v1\"\nmodel = \"meta-llama/Llama-3.1-8B-Instruct\"\napi_key_env = \"\"\n",
+      "setupHint": "Run `vllm serve meta-llama/Llama-3.1-8B-Instruct`. Update `model` to match your deployment.",
+      "url": "https://docs.vllm.ai"
+    },
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "requiresKey": true,
+      "apiKeyEnv": "OPENAI_API_KEY",
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"https://api.openai.com/v1\"\nmodel = \"gpt-4o-mini\"\napi_key_env = \"OPENAI_API_KEY\"\n",
+      "setupHint": "Export `OPENAI_API_KEY=...` in the shell where you run `vaner daemon` / `vaner mcp`.",
+      "url": "https://platform.openai.com/docs/api-reference"
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "requiresKey": true,
+      "apiKeyEnv": "ANTHROPIC_API_KEY",
+      "snippet": "[backend]\nkind = \"anthropic\"\nbase_url = \"https://api.anthropic.com\"\nmodel = \"claude-3-5-sonnet-latest\"\napi_key_env = \"ANTHROPIC_API_KEY\"\n",
+      "setupHint": "Export `ANTHROPIC_API_KEY=...`. Vaner uses the Messages API under the hood.",
+      "url": "https://docs.anthropic.com"
+    },
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "requiresKey": true,
+      "apiKeyEnv": "OPENROUTER_API_KEY",
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"https://openrouter.ai/api/v1\"\nmodel = \"meta-llama/llama-3.1-8b-instruct\"\napi_key_env = \"OPENROUTER_API_KEY\"\n",
+      "setupHint": "Export `OPENROUTER_API_KEY=...`. Pick any model slug from openrouter.ai/models.",
+      "url": "https://openrouter.ai/docs"
+    },
+    {
+      "id": "skip",
+      "name": "Skip for now",
+      "requiresKey": false,
+      "snippet": "# No backend configured.\n# Vaner's ponder loop will be a no-op until you set [backend].\n",
+      "setupHint": "You can pick a backend later with `vaner init --backend-preset <name>`.",
+      "url": "https://docs.vaner.ai/backends"
+    }
+  ]
+}

--- a/content/mcp/clients.json
+++ b/content/mcp/clients.json
@@ -389,7 +389,7 @@
       },
       "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
       "docsSlug": "roo-mcp",
-      "sourceUrl": "https://docs.roocode.com/features/mcp",
+      "sourceUrl": "https://docs.roocode.com/features/mcp/using-mcp-in-roo",
       "launchers": {
         "uvx": {
           "command": "uvx",

--- a/content/mcp/clients.json
+++ b/content/mcp/clients.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "./clients.schema.json",
+  "version": 1,
+  "clients": [
+    {
+      "id": "claude-code",
+      "name": "Claude Code",
+      "category": "cli",
+      "scopes": [
+        { "id": "user", "label": "User" },
+        { "id": "project", "label": "Project" },
+        { "id": "local", "label": "Local" }
+      ],
+      "install": {
+        "kind": "cli",
+        "command": "claude mcp add --transport stdio --scope {scope} vaner -- vaner mcp --path ."
+      },
+      "verify": "Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.",
+      "docsSlug": "claude-code-mcp",
+      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp"
+    },
+    {
+      "id": "cursor",
+      "name": "Cursor",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User (~/.cursor/mcp.json)" },
+        { "id": "project", "label": "Project (.cursor/mcp.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "user": "~/.cursor/mcp.json",
+          "project": ".cursor/mcp.json"
+        }
+      },
+      "verify": "Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
+      "docsSlug": "cursor-mcp",
+      "sourceUrl": "https://docs.cursor.com/en/context/mcp"
+    },
+    {
+      "id": "vscode-copilot",
+      "name": "VS Code (Copilot)",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User profile" },
+        { "id": "project", "label": "Workspace (.vscode/mcp.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \"${workspaceFolder}\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "user": "~/.config/Code/User/mcp.json",
+          "project": ".vscode/mcp.json"
+        }
+      },
+      "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.",
+      "docsSlug": "vscode-copilot-mcp",
+      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+    },
+    {
+      "id": "codex-cli",
+      "name": "Codex CLI",
+      "category": "cli",
+      "scopes": [
+        { "id": "user", "label": "User (~/.codex/config.toml)" }
+      ],
+      "install": {
+        "kind": "cli",
+        "command": "codex mcp add vaner -- vaner mcp --path ."
+      },
+      "verify": "Run `codex mcp list` — `vaner` should appear with status `running`.",
+      "docsSlug": "codex-cli-mcp",
+      "sourceUrl": "https://github.com/openai/codex"
+    },
+    {
+      "id": "windsurf",
+      "name": "Windsurf",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/.codeium/windsurf/mcp_config.json",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
+      "docsSlug": "windsurf-mcp",
+      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp"
+    },
+    {
+      "id": "continue",
+      "name": "Continue",
+      "category": "extension",
+      "scopes": [
+        { "id": "project", "label": "Project (.continue/mcpServers/vaner.yaml)" },
+        { "id": "user", "label": "User (~/.continue/mcpServers/vaner.yaml)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "yaml",
+        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: vaner\nargs:\n  - mcp\n  - --path\n  - .\n",
+        "scopePaths": {
+          "project": ".continue/mcpServers/vaner.yaml",
+          "user": "~/.continue/mcpServers/vaner.yaml"
+        }
+      },
+      "verify": "Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.",
+      "docsSlug": "continue-mcp",
+      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp"
+    },
+    {
+      "id": "zed",
+      "name": "Zed",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User settings.json" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/.config/zed/settings.json",
+        "language": "json",
+        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"vaner\",\n        \"args\": [\"mcp\", \"--path\", \".\"]\n      }\n    }\n  }\n}\n"
+      },
+      "verify": "Restart Zed. Open the Assistant panel; `vaner` should appear under Context Servers.",
+      "docsSlug": "zed-mcp",
+      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol"
+    },
+    {
+      "id": "claude-desktop",
+      "name": "Claude Desktop",
+      "category": "desktop",
+      "scopes": [
+        { "id": "user", "label": "User config" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) · %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.",
+      "docsSlug": "claude-desktop-mcp",
+      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user"
+    },
+    {
+      "id": "cline",
+      "name": "Cline",
+      "category": "extension",
+      "scopes": [
+        { "id": "user", "label": "User" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
+      "docsSlug": "cline-mcp",
+      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers"
+    },
+    {
+      "id": "roo",
+      "name": "Roo Code",
+      "category": "extension",
+      "scopes": [
+        { "id": "project", "label": "Project (.roo/mcp.json)" },
+        { "id": "user", "label": "User (~/.roo/mcp_settings.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "project": ".roo/mcp.json",
+          "user": "~/.roo/mcp_settings.json"
+        }
+      },
+      "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
+      "docsSlug": "roo-mcp",
+      "sourceUrl": "https://docs.roocode.com/features/mcp"
+    }
+  ]
+}

--- a/content/mcp/clients.json
+++ b/content/mcp/clients.json
@@ -7,53 +7,108 @@
       "name": "Claude Code",
       "category": "cli",
       "scopes": [
-        { "id": "user", "label": "User" },
-        { "id": "project", "label": "Project" },
-        { "id": "local", "label": "Local" }
+        {
+          "id": "user",
+          "label": "User"
+        },
+        {
+          "id": "project",
+          "label": "Project"
+        },
+        {
+          "id": "local",
+          "label": "Local"
+        }
       ],
       "install": {
         "kind": "cli",
-        "command": "claude mcp add --transport stdio --scope {scope} vaner -- vaner mcp --path ."
+        "command": "claude mcp add --transport stdio --scope {scope} vaner -- {launcherShellWithDotPath}"
       },
-      "verify": "Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.",
+      "verify": "Run `/mcp` inside a Claude Code session \u2014 `vaner` should appear with the five scenario tools.",
       "docsSlug": "claude-code-mcp",
-      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp"
+      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "cursor",
       "name": "Cursor",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User (~/.cursor/mcp.json)" },
-        { "id": "project", "label": "Project (.cursor/mcp.json)" }
+        {
+          "id": "user",
+          "label": "User (~/.cursor/mcp.json)"
+        },
+        {
+          "id": "project",
+          "label": "Project (.cursor/mcp.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n",
         "scopePaths": {
           "user": "~/.cursor/mcp.json",
           "project": ".cursor/mcp.json"
         }
       },
-      "verify": "Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
+      "verify": "Restart Cursor, open Settings \u2192 MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
       "docsSlug": "cursor-mcp",
-      "sourceUrl": "https://docs.cursor.com/en/context/mcp"
+      "sourceUrl": "https://docs.cursor.com/en/context/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "vscode-copilot",
       "name": "VS Code (Copilot)",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User profile" },
-        { "id": "project", "label": "Workspace (.vscode/mcp.json)" }
+        {
+          "id": "user",
+          "label": "User profile"
+        },
+        {
+          "id": "project",
+          "label": "Workspace (.vscode/mcp.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \"${workspaceFolder}\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithWorkspacePath}\n    }\n  }\n}\n",
         "scopePaths": {
           "user": "~/.config/Code/User/mcp.json",
           "project": ".vscode/mcp.json"
@@ -61,126 +116,272 @@
       },
       "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.",
       "docsSlug": "vscode-copilot-mcp",
-      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "codex-cli",
       "name": "Codex CLI",
       "category": "cli",
       "scopes": [
-        { "id": "user", "label": "User (~/.codex/config.toml)" }
+        {
+          "id": "user",
+          "label": "User (~/.codex/config.toml)"
+        }
       ],
       "install": {
         "kind": "cli",
-        "command": "codex mcp add vaner -- vaner mcp --path ."
+        "command": "codex mcp add vaner -- {launcherShellWithDotPath}"
       },
-      "verify": "Run `codex mcp list` — `vaner` should appear with status `running`.",
+      "verify": "Run `codex mcp list` \u2014 `vaner` should appear with status `running`.",
       "docsSlug": "codex-cli-mcp",
-      "sourceUrl": "https://github.com/openai/codex"
+      "sourceUrl": "https://github.com/openai/codex",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "windsurf",
       "name": "Windsurf",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User" }
+        {
+          "id": "user",
+          "label": "User"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/.codeium/windsurf/mcp_config.json",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
       "docsSlug": "windsurf-mcp",
-      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp"
+      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "continue",
       "name": "Continue",
       "category": "extension",
       "scopes": [
-        { "id": "project", "label": "Project (.continue/mcpServers/vaner.yaml)" },
-        { "id": "user", "label": "User (~/.continue/mcpServers/vaner.yaml)" }
+        {
+          "id": "project",
+          "label": "Project (.continue/mcpServers/vaner.yaml)"
+        },
+        {
+          "id": "user",
+          "label": "User (~/.continue/mcpServers/vaner.yaml)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "yaml",
-        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: vaner\nargs:\n  - mcp\n  - --path\n  - .\n",
+        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: {launcherCommand}\nargs:\n{launcherArgsYamlWithDotPath}\n",
         "scopePaths": {
           "project": ".continue/mcpServers/vaner.yaml",
           "user": "~/.continue/mcpServers/vaner.yaml"
         }
       },
-      "verify": "Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.",
+      "verify": "Reload Continue. Ask the agent to list available MCP tools \u2014 `vaner.list_scenarios` should be present.",
       "docsSlug": "continue-mcp",
-      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp"
+      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "zed",
       "name": "Zed",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User settings.json" }
+        {
+          "id": "user",
+          "label": "User settings.json"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/.config/zed/settings.json",
         "language": "json",
-        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"vaner\",\n        \"args\": [\"mcp\", \"--path\", \".\"]\n      }\n    }\n  }\n}\n"
+        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"{launcherCommand}\",\n        \"args\": {launcherArgsJsonWithDotPath}\n      }\n    }\n  }\n}\n"
       },
       "verify": "Restart Zed. Open the Assistant panel; `vaner` should appear under Context Servers.",
       "docsSlug": "zed-mcp",
-      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol"
+      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "claude-desktop",
       "name": "Claude Desktop",
       "category": "desktop",
       "scopes": [
-        { "id": "user", "label": "User config" }
+        {
+          "id": "user",
+          "label": "User config"
+        }
       ],
       "install": {
         "kind": "file",
-        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) · %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
+        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) \u00b7 %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.",
       "docsSlug": "claude-desktop-mcp",
-      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user"
+      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "cline",
       "name": "Cline",
       "category": "extension",
       "scopes": [
-        { "id": "user", "label": "User" }
+        {
+          "id": "user",
+          "label": "User"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
       "docsSlug": "cline-mcp",
-      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers"
+      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "roo",
       "name": "Roo Code",
       "category": "extension",
       "scopes": [
-        { "id": "project", "label": "Project (.roo/mcp.json)" },
-        { "id": "user", "label": "User (~/.roo/mcp_settings.json)" }
+        {
+          "id": "project",
+          "label": "Project (.roo/mcp.json)"
+        },
+        {
+          "id": "user",
+          "label": "User (~/.roo/mcp_settings.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n",
         "scopePaths": {
           "project": ".roo/mcp.json",
           "user": "~/.roo/mcp_settings.json"
@@ -188,7 +389,24 @@
       },
       "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
       "docsSlug": "roo-mcp",
-      "sourceUrl": "https://docs.roocode.com/features/mcp"
+      "sourceUrl": "https://docs.roocode.com/features/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     }
   ]
 }

--- a/content/mcp/clients.json
+++ b/content/mcp/clients.json
@@ -188,7 +188,7 @@
       },
       "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
       "docsSlug": "windsurf-mcp",
-      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp",
+      "sourceUrl": "https://docs.windsurf.com/windsurf/cascade/mcp",
       "launchers": {
         "uvx": {
           "command": "uvx",
@@ -344,7 +344,7 @@
       },
       "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
       "docsSlug": "cline-mcp",
-      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers",
+      "sourceUrl": "https://docs.cline.bot/mcp/adding-and-configuring-servers",
       "launchers": {
         "uvx": {
           "command": "uvx",

--- a/content/mcp/launchers.json
+++ b/content/mcp/launchers.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./launchers.schema.json",
+  "version": 1,
+  "launchers": [
+    {
+      "id": "uvx",
+      "label": "Run via uvx (recommended)",
+      "description": "No permanent install needed. uvx runs vaner[mcp] on demand.",
+      "command": "uvx",
+      "args": ["--from", "vaner[mcp]", "vaner", "mcp"]
+    },
+    {
+      "id": "path",
+      "label": "Use installed vaner on PATH",
+      "description": "Use an already-installed vaner binary from your shell PATH.",
+      "command": "vaner",
+      "args": ["mcp"]
+    }
+  ]
+}

--- a/lib/mcp-clients.ts
+++ b/lib/mcp-clients.ts
@@ -1,103 +1,139 @@
 import clientsData from '@/content/mcp/clients.json';
 import backendsData from '@/content/mcp/backends.json';
+import launchersData from '@/content/mcp/launchers.json';
+import { z } from 'zod';
 
 export type McpScope = {
   id: string;
   label: string;
 };
 
-export type McpClientInstallCli = {
-  kind: 'cli';
+export type McpLauncherId = 'uvx' | 'path';
+
+export type McpLauncherCommand = {
   command: string;
+  args: string[];
 };
 
-export type McpClientInstallFile = {
-  kind: 'file';
-  path: string;
-  language: string;
-  snippet: string;
-  scopePaths?: Record<string, string>;
-};
+const ScopeSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+});
 
-export type McpClientInstall = McpClientInstallCli | McpClientInstallFile;
+const LauncherCommandSchema = z.object({
+  command: z.string().min(1),
+  args: z.array(z.string()),
+});
 
-export type McpClient = {
-  id: string;
-  name: string;
-  category: 'cli' | 'ide' | 'desktop' | 'extension';
-  scopes: McpScope[];
-  install: McpClientInstall;
-  verify: string;
-  docsSlug: string;
-  sourceUrl: string;
-};
+const ClientInstallCliSchema = z.object({
+  kind: z.literal('cli'),
+  command: z.string().min(1),
+});
 
-export type McpBackend = {
-  id: string;
-  name: string;
-  requiresKey: boolean;
-  apiKeyEnv?: string;
-  snippet: string;
-  setupHint: string;
-  url: string;
-};
+const ClientInstallFileSchema = z.object({
+  kind: z.literal('file'),
+  path: z.string().min(1),
+  language: z.string().min(1),
+  snippet: z.string().min(1),
+  scopePaths: z.record(z.string(), z.string()).optional(),
+});
 
-const KNOWN_CATEGORIES = new Set(['cli', 'ide', 'desktop', 'extension']);
+const ClientSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  category: z.enum(['cli', 'ide', 'desktop', 'extension']),
+  scopes: z.array(ScopeSchema).min(1),
+  install: z.union([ClientInstallCliSchema, ClientInstallFileSchema]),
+  launchers: z.object({
+    uvx: LauncherCommandSchema,
+    path: LauncherCommandSchema,
+  }),
+  verify: z.string().min(1),
+  docsSlug: z.string().min(1),
+  sourceUrl: z.string().url(),
+});
 
-function assert(cond: unknown, msg: string): asserts cond {
-  if (!cond) throw new Error(`[mcp-clients] manifest invalid: ${msg}`);
+const BackendSchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  requiresKey: z.boolean(),
+  apiKeyEnv: z.string().optional(),
+  snippet: z.string().min(1),
+  setupHint: z.string().min(1),
+  url: z.string().url(),
+});
+
+const LauncherSchema = z.object({
+  id: z.enum(['uvx', 'path']),
+  label: z.string().min(1),
+  description: z.string().min(1),
+  command: z.string().min(1),
+  args: z.array(z.string()),
+});
+
+const ClientsManifestSchema = z.object({
+  version: z.number(),
+  clients: z.array(ClientSchema).min(1),
+});
+
+const BackendsManifestSchema = z.object({
+  version: z.number(),
+  backends: z.array(BackendSchema).min(1),
+});
+
+const LaunchersManifestSchema = z.object({
+  version: z.number(),
+  launchers: z.array(LauncherSchema).min(1),
+});
+
+export type McpLauncher = z.infer<typeof LauncherSchema>;
+export type McpClientInstallCli = z.infer<typeof ClientInstallCliSchema>;
+export type McpClientInstallFile = z.infer<typeof ClientInstallFileSchema>;
+export type McpClientInstall = z.infer<typeof ClientSchema>['install'];
+export type McpClient = z.infer<typeof ClientSchema>;
+export type McpBackend = z.infer<typeof BackendSchema>;
+
+function shellEscape(value: string): string {
+  if (/^[A-Za-z0-9_./:-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\"'\"'`)}'`;
 }
 
-function validateClient(raw: unknown, idx: number): McpClient {
-  assert(raw && typeof raw === 'object', `clients[${idx}] is not an object`);
-  const c = raw as Record<string, unknown>;
-  assert(typeof c.id === 'string' && c.id.length > 0, `clients[${idx}].id missing`);
-  assert(typeof c.name === 'string', `clients[${c.id}].name missing`);
-  assert(typeof c.category === 'string' && KNOWN_CATEGORIES.has(c.category as string), `clients[${c.id}].category invalid`);
-  assert(Array.isArray(c.scopes) && c.scopes.length > 0, `clients[${c.id}].scopes empty`);
-  for (const [i, s] of (c.scopes as unknown[]).entries()) {
-    assert(s && typeof s === 'object', `clients[${c.id}].scopes[${i}] not object`);
-    const sc = s as Record<string, unknown>;
-    assert(typeof sc.id === 'string', `clients[${c.id}].scopes[${i}].id missing`);
-    assert(typeof sc.label === 'string', `clients[${c.id}].scopes[${i}].label missing`);
-  }
-  assert(c.install && typeof c.install === 'object', `clients[${c.id}].install missing`);
-  const inst = c.install as Record<string, unknown>;
-  if (inst.kind === 'cli') {
-    assert(typeof inst.command === 'string', `clients[${c.id}].install.command missing`);
-  } else if (inst.kind === 'file') {
-    assert(typeof inst.path === 'string', `clients[${c.id}].install.path missing`);
-    assert(typeof inst.language === 'string', `clients[${c.id}].install.language missing`);
-    assert(typeof inst.snippet === 'string', `clients[${c.id}].install.snippet missing`);
-  } else {
-    throw new Error(`[mcp-clients] clients[${c.id}].install.kind must be 'cli' or 'file'`);
-  }
-  assert(typeof c.verify === 'string', `clients[${c.id}].verify missing`);
-  assert(typeof c.docsSlug === 'string', `clients[${c.id}].docsSlug missing`);
-  assert(typeof c.sourceUrl === 'string', `clients[${c.id}].sourceUrl missing`);
-  return c as unknown as McpClient;
+function renderLauncherArgsYaml(args: string[]): string {
+  return args.map((arg) => `  - ${JSON.stringify(arg)}`).join('\n');
 }
 
-function validateBackend(raw: unknown, idx: number): McpBackend {
-  assert(raw && typeof raw === 'object', `backends[${idx}] not object`);
-  const b = raw as Record<string, unknown>;
-  assert(typeof b.id === 'string', `backends[${idx}].id missing`);
-  assert(typeof b.name === 'string', `backends[${b.id}].name missing`);
-  assert(typeof b.requiresKey === 'boolean', `backends[${b.id}].requiresKey missing`);
-  assert(typeof b.snippet === 'string', `backends[${b.id}].snippet missing`);
-  assert(typeof b.setupHint === 'string', `backends[${b.id}].setupHint missing`);
-  assert(typeof b.url === 'string', `backends[${b.id}].url missing`);
-  return b as unknown as McpBackend;
+function buildLauncherContext(launcher: McpLauncherCommand): Record<string, string> {
+  const dotPathArgs = [...launcher.args, '--path', '.'];
+  const workspaceArgs = [...launcher.args, '--path', '${workspaceFolder}'];
+  return {
+    '{launcherCommand}': launcher.command,
+    '{launcherShell}': [launcher.command, ...launcher.args].map(shellEscape).join(' '),
+    '{launcherShellWithDotPath}': [launcher.command, ...dotPathArgs].map(shellEscape).join(' '),
+    '{launcherArgsJson}': JSON.stringify(launcher.args),
+    '{launcherArgsJsonWithDotPath}': JSON.stringify(dotPathArgs),
+    '{launcherArgsJsonWithWorkspacePath}': JSON.stringify(workspaceArgs),
+    '{launcherArgsYaml}': renderLauncherArgsYaml(launcher.args),
+    '{launcherArgsYamlWithDotPath}': renderLauncherArgsYaml(dotPathArgs),
+  };
+}
+
+function applyLauncherTemplate(template: string, launcher: McpLauncherCommand): string {
+  let result = template;
+  const context = buildLauncherContext(launcher);
+  for (const [token, value] of Object.entries(context)) {
+    result = result.replaceAll(token, value);
+  }
+  return result;
 }
 
 let cachedClients: McpClient[] | null = null;
 let cachedBackends: McpBackend[] | null = null;
+let cachedLaunchers: McpLauncher[] | null = null;
 
 export function getMcpClients(): McpClient[] {
   if (cachedClients) return cachedClients;
-  const raw = clientsData as { clients?: unknown[] };
-  assert(Array.isArray(raw.clients), 'clients manifest missing `clients` array');
-  cachedClients = raw.clients.map(validateClient);
+  const parsed = ClientsManifestSchema.parse(clientsData);
+  cachedClients = parsed.clients;
   return cachedClients;
 }
 
@@ -107,9 +143,8 @@ export function getMcpClient(id: string): McpClient | undefined {
 
 export function getMcpBackends(): McpBackend[] {
   if (cachedBackends) return cachedBackends;
-  const raw = backendsData as { backends?: unknown[] };
-  assert(Array.isArray(raw.backends), 'backends manifest missing `backends` array');
-  cachedBackends = raw.backends.map(validateBackend);
+  const parsed = BackendsManifestSchema.parse(backendsData);
+  cachedBackends = parsed.backends;
   return cachedBackends;
 }
 
@@ -117,18 +152,38 @@ export function getMcpBackend(id: string): McpBackend | undefined {
   return getMcpBackends().find((b) => b.id === id);
 }
 
-export function renderInstallSnippet(client: McpClient, scope: string): { language: string; content: string; path?: string } {
+export function getMcpLaunchers(): McpLauncher[] {
+  if (cachedLaunchers) return cachedLaunchers;
+  const parsed = LaunchersManifestSchema.parse(launchersData);
+  cachedLaunchers = parsed.launchers;
+  return cachedLaunchers;
+}
+
+export function renderInstallSnippet(
+  client: McpClient,
+  scope: string,
+  launcherId: McpLauncherId = 'uvx',
+): { language: string; content: string; path?: string; missingScopePath?: boolean } {
+  const launcher = client.launchers[launcherId] ?? client.launchers.uvx ?? client.launchers.path;
   if (client.install.kind === 'cli') {
     return {
       language: 'bash',
-      content: client.install.command.replace('{scope}', scope),
+      content: applyLauncherTemplate(client.install.command.replace('{scope}', scope), launcher),
     };
   }
   const scopePath = client.install.scopePaths?.[scope];
-  const path = (client.install.path || '').replace('{scopePath}', scopePath ?? client.install.path);
+  const requiresScopePath = client.install.path.includes('{scopePath}');
+  if (requiresScopePath && !scopePath) {
+    return {
+      language: client.install.language,
+      content: applyLauncherTemplate(client.install.snippet, launcher),
+      missingScopePath: true,
+    };
+  }
+  const path = client.install.path.replace('{scopePath}', scopePath ?? '');
   return {
     language: client.install.language,
-    content: client.install.snippet,
+    content: applyLauncherTemplate(client.install.snippet, launcher),
     path,
   };
 }

--- a/lib/mcp-clients.ts
+++ b/lib/mcp-clients.ts
@@ -1,0 +1,134 @@
+import clientsData from '@/content/mcp/clients.json';
+import backendsData from '@/content/mcp/backends.json';
+
+export type McpScope = {
+  id: string;
+  label: string;
+};
+
+export type McpClientInstallCli = {
+  kind: 'cli';
+  command: string;
+};
+
+export type McpClientInstallFile = {
+  kind: 'file';
+  path: string;
+  language: string;
+  snippet: string;
+  scopePaths?: Record<string, string>;
+};
+
+export type McpClientInstall = McpClientInstallCli | McpClientInstallFile;
+
+export type McpClient = {
+  id: string;
+  name: string;
+  category: 'cli' | 'ide' | 'desktop' | 'extension';
+  scopes: McpScope[];
+  install: McpClientInstall;
+  verify: string;
+  docsSlug: string;
+  sourceUrl: string;
+};
+
+export type McpBackend = {
+  id: string;
+  name: string;
+  requiresKey: boolean;
+  apiKeyEnv?: string;
+  snippet: string;
+  setupHint: string;
+  url: string;
+};
+
+const KNOWN_CATEGORIES = new Set(['cli', 'ide', 'desktop', 'extension']);
+
+function assert(cond: unknown, msg: string): asserts cond {
+  if (!cond) throw new Error(`[mcp-clients] manifest invalid: ${msg}`);
+}
+
+function validateClient(raw: unknown, idx: number): McpClient {
+  assert(raw && typeof raw === 'object', `clients[${idx}] is not an object`);
+  const c = raw as Record<string, unknown>;
+  assert(typeof c.id === 'string' && c.id.length > 0, `clients[${idx}].id missing`);
+  assert(typeof c.name === 'string', `clients[${c.id}].name missing`);
+  assert(typeof c.category === 'string' && KNOWN_CATEGORIES.has(c.category as string), `clients[${c.id}].category invalid`);
+  assert(Array.isArray(c.scopes) && c.scopes.length > 0, `clients[${c.id}].scopes empty`);
+  for (const [i, s] of (c.scopes as unknown[]).entries()) {
+    assert(s && typeof s === 'object', `clients[${c.id}].scopes[${i}] not object`);
+    const sc = s as Record<string, unknown>;
+    assert(typeof sc.id === 'string', `clients[${c.id}].scopes[${i}].id missing`);
+    assert(typeof sc.label === 'string', `clients[${c.id}].scopes[${i}].label missing`);
+  }
+  assert(c.install && typeof c.install === 'object', `clients[${c.id}].install missing`);
+  const inst = c.install as Record<string, unknown>;
+  if (inst.kind === 'cli') {
+    assert(typeof inst.command === 'string', `clients[${c.id}].install.command missing`);
+  } else if (inst.kind === 'file') {
+    assert(typeof inst.path === 'string', `clients[${c.id}].install.path missing`);
+    assert(typeof inst.language === 'string', `clients[${c.id}].install.language missing`);
+    assert(typeof inst.snippet === 'string', `clients[${c.id}].install.snippet missing`);
+  } else {
+    throw new Error(`[mcp-clients] clients[${c.id}].install.kind must be 'cli' or 'file'`);
+  }
+  assert(typeof c.verify === 'string', `clients[${c.id}].verify missing`);
+  assert(typeof c.docsSlug === 'string', `clients[${c.id}].docsSlug missing`);
+  assert(typeof c.sourceUrl === 'string', `clients[${c.id}].sourceUrl missing`);
+  return c as unknown as McpClient;
+}
+
+function validateBackend(raw: unknown, idx: number): McpBackend {
+  assert(raw && typeof raw === 'object', `backends[${idx}] not object`);
+  const b = raw as Record<string, unknown>;
+  assert(typeof b.id === 'string', `backends[${idx}].id missing`);
+  assert(typeof b.name === 'string', `backends[${b.id}].name missing`);
+  assert(typeof b.requiresKey === 'boolean', `backends[${b.id}].requiresKey missing`);
+  assert(typeof b.snippet === 'string', `backends[${b.id}].snippet missing`);
+  assert(typeof b.setupHint === 'string', `backends[${b.id}].setupHint missing`);
+  assert(typeof b.url === 'string', `backends[${b.id}].url missing`);
+  return b as unknown as McpBackend;
+}
+
+let cachedClients: McpClient[] | null = null;
+let cachedBackends: McpBackend[] | null = null;
+
+export function getMcpClients(): McpClient[] {
+  if (cachedClients) return cachedClients;
+  const raw = clientsData as { clients?: unknown[] };
+  assert(Array.isArray(raw.clients), 'clients manifest missing `clients` array');
+  cachedClients = raw.clients.map(validateClient);
+  return cachedClients;
+}
+
+export function getMcpClient(id: string): McpClient | undefined {
+  return getMcpClients().find((c) => c.id === id);
+}
+
+export function getMcpBackends(): McpBackend[] {
+  if (cachedBackends) return cachedBackends;
+  const raw = backendsData as { backends?: unknown[] };
+  assert(Array.isArray(raw.backends), 'backends manifest missing `backends` array');
+  cachedBackends = raw.backends.map(validateBackend);
+  return cachedBackends;
+}
+
+export function getMcpBackend(id: string): McpBackend | undefined {
+  return getMcpBackends().find((b) => b.id === id);
+}
+
+export function renderInstallSnippet(client: McpClient, scope: string): { language: string; content: string; path?: string } {
+  if (client.install.kind === 'cli') {
+    return {
+      language: 'bash',
+      content: client.install.command.replace('{scope}', scope),
+    };
+  }
+  const scopePath = client.install.scopePaths?.[scope];
+  const path = (client.install.path || '').replace('{scopePath}', scopePath ?? client.install.path);
+  return {
+    language: client.install.language,
+    content: client.install.snippet,
+    path,
+  };
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,9 +1,15 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
 import type { MDXComponents } from 'mdx/types';
+import { McpClientPickerServer } from '@/components/mcp/client-picker-server';
+import { BackendPresetPickerServer } from '@/components/mcp/backend-picker-server';
+import { ComputeBudget } from '@/components/mcp/compute-budget';
 
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    McpClientPicker: McpClientPickerServer,
+    BackendPresetPicker: BackendPresetPickerServer,
+    ComputeBudget,
     ...components,
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "fumadocs-ui": "^16",
         "next": "^16",
         "react": "^19",
-        "react-dom": "^19"
+        "react-dom": "^19",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/node": "^25",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "prebuild": "node scripts/emit-mcp-manifest.mjs",
+    "sync:mcp-manifest": "node scripts/emit-mcp-manifest.mjs"
   },
   "dependencies": {
     "fumadocs-core": "^16",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "fumadocs-ui": "^16",
     "next": "^16",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25",

--- a/public/mcp-backends.json
+++ b/public/mcp-backends.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "./backends.schema.json",
+  "version": 1,
+  "backends": [
+    {
+      "id": "ollama",
+      "name": "Ollama (local)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:11434/v1\"\nmodel = \"llama3.2:3b\"\napi_key_env = \"\"\n",
+      "setupHint": "Install Ollama and run `ollama pull llama3.2:3b`. Ollama exposes an OpenAI-compatible endpoint on port 11434.",
+      "url": "https://ollama.com"
+    },
+    {
+      "id": "lmstudio",
+      "name": "LM Studio (local)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:1234/v1\"\nmodel = \"local-model\"\napi_key_env = \"\"\n",
+      "setupHint": "Open LM Studio → Developer → Start Server. Replace `local-model` with the identifier shown in the server log.",
+      "url": "https://lmstudio.ai"
+    },
+    {
+      "id": "vllm",
+      "name": "vLLM (self-hosted)",
+      "requiresKey": false,
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"http://127.0.0.1:8000/v1\"\nmodel = \"meta-llama/Llama-3.1-8B-Instruct\"\napi_key_env = \"\"\n",
+      "setupHint": "Run `vllm serve meta-llama/Llama-3.1-8B-Instruct`. Update `model` to match your deployment.",
+      "url": "https://docs.vllm.ai"
+    },
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "requiresKey": true,
+      "apiKeyEnv": "OPENAI_API_KEY",
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"https://api.openai.com/v1\"\nmodel = \"gpt-4o-mini\"\napi_key_env = \"OPENAI_API_KEY\"\n",
+      "setupHint": "Export `OPENAI_API_KEY=...` in the shell where you run `vaner daemon` / `vaner mcp`.",
+      "url": "https://platform.openai.com/docs/api-reference"
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "requiresKey": true,
+      "apiKeyEnv": "ANTHROPIC_API_KEY",
+      "snippet": "[backend]\nkind = \"anthropic\"\nbase_url = \"https://api.anthropic.com\"\nmodel = \"claude-3-5-sonnet-latest\"\napi_key_env = \"ANTHROPIC_API_KEY\"\n",
+      "setupHint": "Export `ANTHROPIC_API_KEY=...`. Vaner uses the Messages API under the hood.",
+      "url": "https://docs.anthropic.com"
+    },
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "requiresKey": true,
+      "apiKeyEnv": "OPENROUTER_API_KEY",
+      "snippet": "[backend]\nkind = \"openai\"\nbase_url = \"https://openrouter.ai/api/v1\"\nmodel = \"meta-llama/llama-3.1-8b-instruct\"\napi_key_env = \"OPENROUTER_API_KEY\"\n",
+      "setupHint": "Export `OPENROUTER_API_KEY=...`. Pick any model slug from openrouter.ai/models.",
+      "url": "https://openrouter.ai/docs"
+    },
+    {
+      "id": "skip",
+      "name": "Skip for now",
+      "requiresKey": false,
+      "snippet": "# No backend configured.\n# Vaner's ponder loop will be a no-op until you set [backend].\n",
+      "setupHint": "You can pick a backend later with `vaner init --backend-preset <name>`.",
+      "url": "https://docs.vaner.ai/backends"
+    }
+  ]
+}

--- a/public/mcp-clients.json
+++ b/public/mcp-clients.json
@@ -389,7 +389,7 @@
       },
       "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
       "docsSlug": "roo-mcp",
-      "sourceUrl": "https://docs.roocode.com/features/mcp",
+      "sourceUrl": "https://docs.roocode.com/features/mcp/using-mcp-in-roo",
       "launchers": {
         "uvx": {
           "command": "uvx",

--- a/public/mcp-clients.json
+++ b/public/mcp-clients.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "./clients.schema.json",
+  "version": 1,
+  "clients": [
+    {
+      "id": "claude-code",
+      "name": "Claude Code",
+      "category": "cli",
+      "scopes": [
+        { "id": "user", "label": "User" },
+        { "id": "project", "label": "Project" },
+        { "id": "local", "label": "Local" }
+      ],
+      "install": {
+        "kind": "cli",
+        "command": "claude mcp add --transport stdio --scope {scope} vaner -- vaner mcp --path ."
+      },
+      "verify": "Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.",
+      "docsSlug": "claude-code-mcp",
+      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp"
+    },
+    {
+      "id": "cursor",
+      "name": "Cursor",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User (~/.cursor/mcp.json)" },
+        { "id": "project", "label": "Project (.cursor/mcp.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "user": "~/.cursor/mcp.json",
+          "project": ".cursor/mcp.json"
+        }
+      },
+      "verify": "Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
+      "docsSlug": "cursor-mcp",
+      "sourceUrl": "https://docs.cursor.com/en/context/mcp"
+    },
+    {
+      "id": "vscode-copilot",
+      "name": "VS Code (Copilot)",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User profile" },
+        { "id": "project", "label": "Workspace (.vscode/mcp.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \"${workspaceFolder}\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "user": "~/.config/Code/User/mcp.json",
+          "project": ".vscode/mcp.json"
+        }
+      },
+      "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.",
+      "docsSlug": "vscode-copilot-mcp",
+      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+    },
+    {
+      "id": "codex-cli",
+      "name": "Codex CLI",
+      "category": "cli",
+      "scopes": [
+        { "id": "user", "label": "User (~/.codex/config.toml)" }
+      ],
+      "install": {
+        "kind": "cli",
+        "command": "codex mcp add vaner -- vaner mcp --path ."
+      },
+      "verify": "Run `codex mcp list` — `vaner` should appear with status `running`.",
+      "docsSlug": "codex-cli-mcp",
+      "sourceUrl": "https://github.com/openai/codex"
+    },
+    {
+      "id": "windsurf",
+      "name": "Windsurf",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/.codeium/windsurf/mcp_config.json",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
+      "docsSlug": "windsurf-mcp",
+      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp"
+    },
+    {
+      "id": "continue",
+      "name": "Continue",
+      "category": "extension",
+      "scopes": [
+        { "id": "project", "label": "Project (.continue/mcpServers/vaner.yaml)" },
+        { "id": "user", "label": "User (~/.continue/mcpServers/vaner.yaml)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "yaml",
+        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: vaner\nargs:\n  - mcp\n  - --path\n  - .\n",
+        "scopePaths": {
+          "project": ".continue/mcpServers/vaner.yaml",
+          "user": "~/.continue/mcpServers/vaner.yaml"
+        }
+      },
+      "verify": "Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.",
+      "docsSlug": "continue-mcp",
+      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp"
+    },
+    {
+      "id": "zed",
+      "name": "Zed",
+      "category": "ide",
+      "scopes": [
+        { "id": "user", "label": "User settings.json" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/.config/zed/settings.json",
+        "language": "json",
+        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"vaner\",\n        \"args\": [\"mcp\", \"--path\", \".\"]\n      }\n    }\n  }\n}\n"
+      },
+      "verify": "Restart Zed. Open the Assistant panel; `vaner` should appear under Context Servers.",
+      "docsSlug": "zed-mcp",
+      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol"
+    },
+    {
+      "id": "claude-desktop",
+      "name": "Claude Desktop",
+      "category": "desktop",
+      "scopes": [
+        { "id": "user", "label": "User config" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) · %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.",
+      "docsSlug": "claude-desktop-mcp",
+      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user"
+    },
+    {
+      "id": "cline",
+      "name": "Cline",
+      "category": "extension",
+      "scopes": [
+        { "id": "user", "label": "User" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+      },
+      "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
+      "docsSlug": "cline-mcp",
+      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers"
+    },
+    {
+      "id": "roo",
+      "name": "Roo Code",
+      "category": "extension",
+      "scopes": [
+        { "id": "project", "label": "Project (.roo/mcp.json)" },
+        { "id": "user", "label": "User (~/.roo/mcp_settings.json)" }
+      ],
+      "install": {
+        "kind": "file",
+        "path": "{scopePath}",
+        "language": "json",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "scopePaths": {
+          "project": ".roo/mcp.json",
+          "user": "~/.roo/mcp_settings.json"
+        }
+      },
+      "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
+      "docsSlug": "roo-mcp",
+      "sourceUrl": "https://docs.roocode.com/features/mcp"
+    }
+  ]
+}

--- a/public/mcp-clients.json
+++ b/public/mcp-clients.json
@@ -7,53 +7,108 @@
       "name": "Claude Code",
       "category": "cli",
       "scopes": [
-        { "id": "user", "label": "User" },
-        { "id": "project", "label": "Project" },
-        { "id": "local", "label": "Local" }
+        {
+          "id": "user",
+          "label": "User"
+        },
+        {
+          "id": "project",
+          "label": "Project"
+        },
+        {
+          "id": "local",
+          "label": "Local"
+        }
       ],
       "install": {
         "kind": "cli",
-        "command": "claude mcp add --transport stdio --scope {scope} vaner -- vaner mcp --path ."
+        "command": "claude mcp add --transport stdio --scope {scope} vaner -- {launcherShellWithDotPath}"
       },
-      "verify": "Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.",
+      "verify": "Run `/mcp` inside a Claude Code session \u2014 `vaner` should appear with the five scenario tools.",
       "docsSlug": "claude-code-mcp",
-      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp"
+      "sourceUrl": "https://docs.anthropic.com/en/docs/claude-code/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "cursor",
       "name": "Cursor",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User (~/.cursor/mcp.json)" },
-        { "id": "project", "label": "Project (.cursor/mcp.json)" }
+        {
+          "id": "user",
+          "label": "User (~/.cursor/mcp.json)"
+        },
+        {
+          "id": "project",
+          "label": "Project (.cursor/mcp.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n",
         "scopePaths": {
           "user": "~/.cursor/mcp.json",
           "project": ".cursor/mcp.json"
         }
       },
-      "verify": "Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
+      "verify": "Restart Cursor, open Settings \u2192 MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
       "docsSlug": "cursor-mcp",
-      "sourceUrl": "https://docs.cursor.com/en/context/mcp"
+      "sourceUrl": "https://docs.cursor.com/en/context/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "vscode-copilot",
       "name": "VS Code (Copilot)",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User profile" },
-        { "id": "project", "label": "Workspace (.vscode/mcp.json)" }
+        {
+          "id": "user",
+          "label": "User profile"
+        },
+        {
+          "id": "project",
+          "label": "Workspace (.vscode/mcp.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \"${workspaceFolder}\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"servers\": {\n    \"vaner\": {\n      \"type\": \"stdio\",\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithWorkspacePath}\n    }\n  }\n}\n",
         "scopePaths": {
           "user": "~/.config/Code/User/mcp.json",
           "project": ".vscode/mcp.json"
@@ -61,126 +116,272 @@
       },
       "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.",
       "docsSlug": "vscode-copilot-mcp",
-      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers"
+      "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "codex-cli",
       "name": "Codex CLI",
       "category": "cli",
       "scopes": [
-        { "id": "user", "label": "User (~/.codex/config.toml)" }
+        {
+          "id": "user",
+          "label": "User (~/.codex/config.toml)"
+        }
       ],
       "install": {
         "kind": "cli",
-        "command": "codex mcp add vaner -- vaner mcp --path ."
+        "command": "codex mcp add vaner -- {launcherShellWithDotPath}"
       },
-      "verify": "Run `codex mcp list` — `vaner` should appear with status `running`.",
+      "verify": "Run `codex mcp list` \u2014 `vaner` should appear with status `running`.",
       "docsSlug": "codex-cli-mcp",
-      "sourceUrl": "https://github.com/openai/codex"
+      "sourceUrl": "https://github.com/openai/codex",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "windsurf",
       "name": "Windsurf",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User" }
+        {
+          "id": "user",
+          "label": "User"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/.codeium/windsurf/mcp_config.json",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
       "docsSlug": "windsurf-mcp",
-      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp"
+      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "continue",
       "name": "Continue",
       "category": "extension",
       "scopes": [
-        { "id": "project", "label": "Project (.continue/mcpServers/vaner.yaml)" },
-        { "id": "user", "label": "User (~/.continue/mcpServers/vaner.yaml)" }
+        {
+          "id": "project",
+          "label": "Project (.continue/mcpServers/vaner.yaml)"
+        },
+        {
+          "id": "user",
+          "label": "User (~/.continue/mcpServers/vaner.yaml)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "yaml",
-        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: vaner\nargs:\n  - mcp\n  - --path\n  - .\n",
+        "snippet": "name: vaner\nversion: 0.0.1\nschema: v1\ncommand: {launcherCommand}\nargs:\n{launcherArgsYamlWithDotPath}\n",
         "scopePaths": {
           "project": ".continue/mcpServers/vaner.yaml",
           "user": "~/.continue/mcpServers/vaner.yaml"
         }
       },
-      "verify": "Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.",
+      "verify": "Reload Continue. Ask the agent to list available MCP tools \u2014 `vaner.list_scenarios` should be present.",
       "docsSlug": "continue-mcp",
-      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp"
+      "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "zed",
       "name": "Zed",
       "category": "ide",
       "scopes": [
-        { "id": "user", "label": "User settings.json" }
+        {
+          "id": "user",
+          "label": "User settings.json"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/.config/zed/settings.json",
         "language": "json",
-        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"vaner\",\n        \"args\": [\"mcp\", \"--path\", \".\"]\n      }\n    }\n  }\n}\n"
+        "snippet": "{\n  \"context_servers\": {\n    \"vaner\": {\n      \"command\": {\n        \"path\": \"{launcherCommand}\",\n        \"args\": {launcherArgsJsonWithDotPath}\n      }\n    }\n  }\n}\n"
       },
       "verify": "Restart Zed. Open the Assistant panel; `vaner` should appear under Context Servers.",
       "docsSlug": "zed-mcp",
-      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol"
+      "sourceUrl": "https://zed.dev/docs/assistant/model-context-protocol",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "claude-desktop",
       "name": "Claude Desktop",
       "category": "desktop",
       "scopes": [
-        { "id": "user", "label": "User config" }
+        {
+          "id": "user",
+          "label": "User config"
+        }
       ],
       "install": {
         "kind": "file",
-        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) · %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
+        "path": "~/Library/Application Support/Claude/claude_desktop_config.json (macOS) \u00b7 %APPDATA%\\\\Claude\\\\claude_desktop_config.json (Windows)",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.",
       "docsSlug": "claude-desktop-mcp",
-      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user"
+      "sourceUrl": "https://modelcontextprotocol.io/quickstart/user",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "cline",
       "name": "Cline",
       "category": "extension",
       "scopes": [
-        { "id": "user", "label": "User" }
+        {
+          "id": "user",
+          "label": "User"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n"
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
       "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
       "docsSlug": "cline-mcp",
-      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers"
+      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     },
     {
       "id": "roo",
       "name": "Roo Code",
       "category": "extension",
       "scopes": [
-        { "id": "project", "label": "Project (.roo/mcp.json)" },
-        { "id": "user", "label": "User (~/.roo/mcp_settings.json)" }
+        {
+          "id": "project",
+          "label": "Project (.roo/mcp.json)"
+        },
+        {
+          "id": "user",
+          "label": "User (~/.roo/mcp_settings.json)"
+        }
       ],
       "install": {
         "kind": "file",
         "path": "{scopePath}",
         "language": "json",
-        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"vaner\",\n      \"args\": [\"mcp\", \"--path\", \".\"]\n    }\n  }\n}\n",
+        "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n",
         "scopePaths": {
           "project": ".roo/mcp.json",
           "user": "~/.roo/mcp_settings.json"
@@ -188,7 +389,24 @@
       },
       "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
       "docsSlug": "roo-mcp",
-      "sourceUrl": "https://docs.roocode.com/features/mcp"
+      "sourceUrl": "https://docs.roocode.com/features/mcp",
+      "launchers": {
+        "uvx": {
+          "command": "uvx",
+          "args": [
+            "--from",
+            "vaner[mcp]",
+            "vaner",
+            "mcp"
+          ]
+        },
+        "path": {
+          "command": "vaner",
+          "args": [
+            "mcp"
+          ]
+        }
+      }
     }
   ]
 }

--- a/public/mcp-clients.json
+++ b/public/mcp-clients.json
@@ -188,7 +188,7 @@
       },
       "verify": "Restart Windsurf. Open Cascade and confirm the Vaner tools appear when prompting about this repo.",
       "docsSlug": "windsurf-mcp",
-      "sourceUrl": "https://docs.windsurf.com/windsurf/mcp",
+      "sourceUrl": "https://docs.windsurf.com/windsurf/cascade/mcp",
       "launchers": {
         "uvx": {
           "command": "uvx",
@@ -344,7 +344,7 @@
       },
       "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
       "docsSlug": "cline-mcp",
-      "sourceUrl": "https://docs.cline.bot/features/mcp-servers/configuring-mcp-servers",
+      "sourceUrl": "https://docs.cline.bot/mcp/adding-and-configuring-servers",
       "launchers": {
         "uvx": {
           "command": "uvx",

--- a/public/mcp-launchers.json
+++ b/public/mcp-launchers.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "./launchers.schema.json",
+  "version": 1,
+  "launchers": [
+    {
+      "id": "uvx",
+      "label": "Run via uvx (recommended)",
+      "description": "No permanent install needed. uvx runs vaner[mcp] on demand.",
+      "command": "uvx",
+      "args": ["--from", "vaner[mcp]", "vaner", "mcp"]
+    },
+    {
+      "id": "path",
+      "label": "Use installed vaner on PATH",
+      "description": "Use an already-installed vaner binary from your shell PATH.",
+      "command": "vaner",
+      "args": ["mcp"]
+    }
+  ]
+}

--- a/scripts/emit-mcp-manifest.mjs
+++ b/scripts/emit-mcp-manifest.mjs
@@ -5,6 +5,7 @@
 import { copyFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { validateManifest } from './mcp-schema.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
@@ -12,16 +13,20 @@ const repoRoot = resolve(__dirname, '..');
 const sources = [
   ['content/mcp/clients.json', 'public/mcp-clients.json'],
   ['content/mcp/backends.json', 'public/mcp-backends.json'],
+  ['content/mcp/launchers.json', 'public/mcp-launchers.json'],
 ];
 
-function validate(file, key) {
+function validate(file) {
   const raw = readFileSync(file, 'utf8');
   const parsed = JSON.parse(raw);
-  if (!Array.isArray(parsed[key])) {
-    throw new Error(`[emit-mcp-manifest] ${file} missing '${key}' array`);
-  }
-  if (parsed[key].length === 0) {
-    throw new Error(`[emit-mcp-manifest] ${file} has empty '${key}' array`);
+  try {
+    validateManifest(file, parsed);
+  } catch (error) {
+    throw new Error(
+      `[emit-mcp-manifest] ${file} failed schema validation: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
   }
 }
 
@@ -31,8 +36,7 @@ for (const [src, dst] of sources) {
   if (!existsSync(srcPath)) {
     throw new Error(`[emit-mcp-manifest] missing source ${src}`);
   }
-  const key = src.endsWith('clients.json') ? 'clients' : 'backends';
-  validate(srcPath, key);
+  validate(srcPath);
   mkdirSync(dirname(dstPath), { recursive: true });
   copyFileSync(srcPath, dstPath);
   console.log(`[emit-mcp-manifest] ${src} -> ${dst}`);

--- a/scripts/emit-mcp-manifest.mjs
+++ b/scripts/emit-mcp-manifest.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Copies content/mcp/*.json into public/ so docs.vaner.ai can serve the
+// manifest as a JSON endpoint for vaner-web (and other consumers).
+
+import { copyFileSync, mkdirSync, readFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const sources = [
+  ['content/mcp/clients.json', 'public/mcp-clients.json'],
+  ['content/mcp/backends.json', 'public/mcp-backends.json'],
+];
+
+function validate(file, key) {
+  const raw = readFileSync(file, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed[key])) {
+    throw new Error(`[emit-mcp-manifest] ${file} missing '${key}' array`);
+  }
+  if (parsed[key].length === 0) {
+    throw new Error(`[emit-mcp-manifest] ${file} has empty '${key}' array`);
+  }
+}
+
+for (const [src, dst] of sources) {
+  const srcPath = resolve(repoRoot, src);
+  const dstPath = resolve(repoRoot, dst);
+  if (!existsSync(srcPath)) {
+    throw new Error(`[emit-mcp-manifest] missing source ${src}`);
+  }
+  const key = src.endsWith('clients.json') ? 'clients' : 'backends';
+  validate(srcPath, key);
+  mkdirSync(dirname(dstPath), { recursive: true });
+  copyFileSync(srcPath, dstPath);
+  console.log(`[emit-mcp-manifest] ${src} -> ${dst}`);
+}

--- a/scripts/mcp-schema.mjs
+++ b/scripts/mcp-schema.mjs
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+
+const ClientsManifestSchema = z.object({
+  version: z.number(),
+  clients: z.array(z.object({ id: z.string().min(1) })).min(1),
+});
+
+const BackendsManifestSchema = z.object({
+  version: z.number(),
+  backends: z.array(z.object({ id: z.string().min(1) })).min(1),
+});
+
+const LaunchersManifestSchema = z.object({
+  version: z.number(),
+  launchers: z.array(
+    z.object({
+      id: z.enum(['uvx', 'path']),
+      command: z.string().min(1),
+      args: z.array(z.string()),
+    }),
+  ).min(1),
+});
+
+export function validateManifest(file, parsed) {
+  if (file.endsWith('clients.json')) {
+    return ClientsManifestSchema.parse(parsed);
+  }
+  if (file.endsWith('backends.json')) {
+    return BackendsManifestSchema.parse(parsed);
+  }
+  return LaunchersManifestSchema.parse(parsed);
+}


### PR DESCRIPTION
## Summary

Adds a self-serve "Connect your AI client" flow across `docs.vaner.ai`.

- **Single source of truth** for 10 MCP clients (Claude Code, Cursor, VS Code Copilot, Codex CLI, Windsurf, Continue, Zed, Claude Desktop, Cline, Roo) and 7 backend presets (Ollama, LM Studio, vLLM, OpenAI, Anthropic, OpenRouter, skip) in \`content/mcp/clients.json\` + \`content/mcp/backends.json\`.
- **\`lib/mcp-clients.ts\`**: typed loader with runtime validation; build fails loudly if the manifest drifts from the schema.
- **\`scripts/emit-mcp-manifest.mjs\` + prebuild**: mirrors manifests to \`public/mcp-{clients,backends}.json\` so \`vaner-web\` (and any other consumer) can fetch them.
- **Picker components** (\`components/mcp/{client-picker,backend-picker,compute-budget}.tsx\`) wired through \`mdx-components.tsx\` so MDX authors can drop \`<McpClientPicker />\`, \`<BackendPresetPicker />\`, and \`<ComputeBudget />\` anywhere.
- **New \`/mcp\` hub** (\`content/docs/mcp/index.mdx\`): Install → Backend → Client → optional ponder caps.
- **Per-client guides** (\`content/docs/integrations/tools/*-mcp.mdx\`): 10 new pages (includes Cline + Roo) driven off the manifest with scope toggles and a verify step.
- **\`integrations/mcp.mdx\`** slimmed to a conceptual overview pointing at \`/mcp\` for setup.
- **\`getting-started.mdx\`** rewritten around the MCP-first flow with non-interactive installer examples and env var mirrors.
- **\`index.mdx\`** removes the GitHub-star iframe and links directly to \`/mcp\`.

Pairs with:
- https://github.com/Borgels/vaner/pull/105 (installer + \`vaner init\` backend picker)
- Companion vaner-web PR for the homepage Connect section.

## Test plan

- [ ] \`npm install && npm run sync:mcp-manifest && npx tsc --noEmit\` passes.
- [ ] \`npm run build\` produces the docs with \`public/mcp-clients.json\` and \`public/mcp-backends.json\`.
- [ ] Spot-check \`/mcp\` and three per-client pages (Claude Code, Cursor, Codex CLI) on \`npm run dev\`.
- [ ] Verify sidebar shows "Connect your client" under the root.

Made with [Cursor](https://cursor.com)