### PR TITLE
Sync CLI UX polish and renamed config keys

### DIFF
--- a/content/docs/cli.mdx
+++ b/content/docs/cli.mdx
@@ -6,8 +6,8 @@ description: Core Vaner CLI commands for MCP-first setup, cockpit, and scenarios
 ## Setup and daemon
 
 ```bash
-vaner init --profile minimal --path .
-vaner daemon start --no-once --path .
+vaner init --path .
+vaner daemon start --once false --path .
 vaner daemon serve-http --path .
 vaner daemon status --path .
 vaner daemon stop --path .
@@ -28,8 +28,8 @@ vaner scenarios outcome <scenario_id> --result useful --skill vaner-feedback --p
 ```bash
 vaner query "where is auth enforced?" --path .
 vaner why --path .
-vaner compare "prompt a" "prompt b" --path .
-vaner impact "refactor auth middleware" --path .
+vaner compare "Summarize auth flow" --path .
+vaner impact --path .
 ```
 
 ## Local debugging and state control
@@ -37,6 +37,8 @@ vaner impact "refactor auth middleware" --path .
 ```bash
 vaner inspect --last --path .
 vaner metrics --path . --output summary
+vaner prepare --path .
+vaner precompute --path .
 vaner forget --path .
 ```
 
@@ -52,8 +54,10 @@ vaner distill-skill <decision-id> --path . [--out-dir PATH] [--name NAME] [--for
 
 ```bash
 vaner watch --cockpit-url http://127.0.0.1:8473
+vaner logs --cockpit-url http://127.0.0.1:8473
 vaner show --cockpit-url http://127.0.0.1:8473
 vaner status --path .
+vaner ps --path .
 vaner doctor --path .
 ```
 
@@ -61,8 +65,15 @@ vaner doctor --path .
 
 ```bash
 vaner config show --path .
+vaner config show --json --path .
+vaner config keys --path .
+vaner config get backend.model --path .
 vaner config set intent.enabled true --path .
+vaner config set intent.skills_loop.enabled true --path .
+vaner config set gateway.routes.gpt- https://api.openai.com/v1 --path .
+vaner config edit --path .
 vaner profile show --path .
+vaner upgrade
 ```
 
 ## MCP server
@@ -84,7 +95,14 @@ Use this only when your client cannot call MCP tools directly.
 
 ```bash
 vaner eval --path .
-vaner run-eval --dataset examples/evals/basic.jsonl --path .
+vaner run-eval --cases-file examples/evals/basic.jsonl --path .
+```
+
+## Version and completion
+
+```bash
+vaner --version
+vaner --install-completion
 ```
 
 Run `vaner --help` and `vaner <subcommand> --help` for full flags.

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -36,12 +36,13 @@ excluded_patterns = ["*.env", "*.key", "*.pem", "credentials*", "secrets*"]
 redact_patterns = ["sk-[a-zA-Z0-9_-]{20,}"]
 
 [compute]
-device = "cpu"
+device = "auto"
 cpu_fraction = 0.25
 gpu_memory_fraction = 0.4
 idle_only = true
 idle_cpu_threshold = 0.6
 idle_gpu_threshold = 0.7
+embedding_device = "cpu"
 max_cycle_seconds = 300
 max_session_minutes = 30
 
@@ -50,6 +51,11 @@ max_exploration_depth = 3
 frontier_max_size = 500
 min_priority = 0.10
 llm_gate = "non_trivial"
+endpoint = ""
+model = ""
+backend = "auto"
+api_key = ""
+embedding_model = "all-MiniLM-L6-v2"
 ```
 
 ## Key sections
@@ -57,9 +63,19 @@ llm_gate = "non_trivial"
 - `mcp`: MCP server transport and host/port for SSE mode.
 - `intent`: skill discovery roots and whether feedback adapts frontier behavior.
 - `exploration`: controls speculative scenario preparation behavior.
+- `exploration.endpoint/model/backend`: optional dedicated exploration LLM (separate from user-facing backend).
+- `exploration.embedding_model`: semantic embedding model for cache matching.
 - `gateway.passthrough`: optional OpenAI-compatible proxy capability (`false` by default).
-- `backend`: local/runtime model endpoint used by the exploration loop.
+- `backend`: user-facing model endpoint used for proxy mode.
 - `privacy`: include/exclude/redaction rules.
-- `compute`: CPU/GPU limits, idle-only guardrails, and ponder wall-clock caps.
+- `compute`: CPU/GPU limits, embedding device selection, idle-only guardrails, and ponder wall-clock caps.
 
-Use `vaner init --profile minimal|advanced|multi` to scaffold configs with different detail levels.
+### CLI shortcuts
+
+```bash
+vaner config keys --path .
+vaner config get backend.model --path .
+vaner config set backend.model qwen3.5:35b --path .
+vaner config set gateway.routes.gpt- https://api.openai.com/v1 --path .
+vaner config edit --path .
+```


### PR DESCRIPTION
## Summary
- update CLI docs to include the new command surface (`--version`, aliases, config workflows, upgrade, completion)
- align configuration docs with renamed exploration keys and compute embedding device guidance
- add concrete `vaner config` shortcut examples for discoverability

## Test plan
- [x] docs content review in local diff
- [x] link/command spot-check for new examples

Made with [Cursor](https://cursor.com)