### PR TITLE
fix(docs): search API, layout CSS, GitHub changelog sync and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,31 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  changelog-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: "22"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Regenerate changelog from GitHub Releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run sync:changelog -- --force
+      - name: Fail if content/docs/changelog.mdx is out of sync
+        run: |
+          if ! git diff --exit-code -- content/docs/changelog.mdx; then
+            echo "::error::content/docs/changelog.mdx does not match GitHub Releases. Run \`npm run sync:changelog -- --force\` locally and commit the updated file."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ next-env.d.ts
 
 # fumadocs generated
 .source/
+
+# github changelog sync cache (optional; omit if you want reproducible offline sync)
+scripts/.cache/

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,12 @@
+import { createFromSource } from 'fumadocs-core/search/server';
+import { source } from '@/lib/source';
+
+const handler = createFromSource(source);
+
+export async function GET(request: Request) {
+  try {
+    return await handler.GET(request);
+  } catch {
+    return Response.json({ error: 'Search unavailable' }, { status: 500 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,1 +1,24 @@
 @import 'fumadocs-ui/style.css';
+
+@layer base {
+  /*
+   * Fumadocs uses a sticky sidebar; `overflow-x: clip` on the docs grid can prevent
+   * sticky positioning from behaving correctly in some browsers.
+   */
+  #nd-docs-layout {
+    overflow-x: visible;
+  }
+
+  /*
+   * Sidebar footer merges ThemeSwitch with utility classes that strip rounding;
+   * restore a clear pill toggle so light/dark matches the rest of the UI.
+   */
+  #nd-sidebar [data-theme-toggle] {
+    border-radius: 9999px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--color-fd-border);
+    background-color: var(--color-fd-background);
+  }
+}
+

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -3,6 +3,8 @@ title: Changelog
 description: Notable changes in Vaner documentation and releases.
 ---
 
+Notable product releases are published on [**GitHub Releases**](https://github.com/Borgels/vaner/releases) (downloads, tags, and discussion). The sections below track **docs-only** edits in progress and mirror **published** release notes into this page.
+
 ## Unreleased
 
 - Reframed docs around MCP-first architecture: model path via MCP tools by default, with proxy/gateway documented as advanced compatibility mode.
@@ -13,8 +15,172 @@ description: Notable changes in Vaner documentation and releases.
 - Added Agent Skills integration docs: skill discovery roots, loop architecture, `vaner distill-skill`, and managed feedback skill flow.
 - Corrected MCP tools list in `/integrations/mcp` to match the actual shipped tool surface.
 
-## 0.1.0
+{/* sync:github-releases begin */}
 
-- Initial release of core Vaner architecture.
-- Local artifact store, daemon loop, broker, and CLI.
-- OpenAI-compatible proxy integration.
+_The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog`._
+
+## v0.6.1
+
+_Released April 21, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.1)_
+
+## Highlights
+- Fix MCP server startup for stdio/SSE by passing explicit notification capabilities.
+- Restore `vaner config show/keys` stability with intent config compatibility.
+- Add backup-file idempotence and rotation for repeated MCP client wiring.
+- Harden installer MCP dependency resolution and add `vaner uninstall`.
+- Include regression tests and updated installer-first docs/site flows.
+
+See full changelog in `CHANGELOG.md`.
+
+## v0.6.0
+
+_Released April 21, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.0)_
+
+## What's Changed
+* fix(ux): harden installer safety, upgrades, and hardware detection by @abolsen in https://github.com/Borgels/vaner/pull/112
+* chore(deps): bump pydantic from 2.13.2 to 2.13.3 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/123
+* chore(deps): bump atheris from 2.3.0 to 3.0.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/121
+* chore(deps): bump pytest-randomly from 4.0.1 to 4.1.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/122
+* chore(deps): bump cyclonedx-bom from 4.6.1 to 7.3.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/120
+* chore(deps): bump sigstore/cosign-installer from 1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 to dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da by @dependabot[bot] in https://github.com/Borgels/vaner/pull/118
+* chore(deps): bump build from 1.2.2.post1 to 1.4.3 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/119
+* chore(deps): bump actions/download-artifact from 4.1.8 to 8.0.1 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/116
+* chore(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/117
+* chore(deps): bump docker/login-action from 3.7.0 to 4.1.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/115
+* chore(deps): bump actions/checkout from 4.1.1 to 6.0.2 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/114
+* feat(mcp): v1.0 redesign + first-class memory semantics by @abolsen in https://github.com/Borgels/vaner/pull/113
+
+## New Contributors
+* @dependabot[bot] made their first contribution in https://github.com/Borgels/vaner/pull/123
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.4.0...v0.6.0
+
+## v0.4.0
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.4.0)_
+
+## Vaner 0.4.0
+
+### Onboarding rescue
+- Added `vaner up` / `vaner down` for a supervised one-command startup and shutdown path.
+- Unified `vaner status` and `vaner doctor` via a shared runtime snapshot for consistent health reporting.
+- Hardened startup reliability with preflight checks (repo-root safety, inotify headroom, busy-port remediation).
+- Added inotify overflow fallback to polling watcher mode instead of crashing.
+- Extended `vaner logs` to include daemon and cockpit runtime logs.
+
+### UX and docs
+- Updated installer next-steps messaging to point users to `vaner up` + `vaner doctor`.
+- Updated README, docs site, and web onboarding callouts for minimal-friction install-to-first-value.
+
+### Quality
+- Full Vaner suite green (245 passing tests) and lint checks clean at release cut.
+
+## v0.3.0
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.3.0)_
+
+## Highlights
+- MCP-first skills-loop improvements including scenario feedback plumbing and `vaner distill-skill`
+- CLI UX polish (`--version`, grouped help, config get/keys/edit, aliases, richer doctor output, `vaner upgrade`)
+- Hermetic eval/query core test lane (no sentence-transformers dependency in default CI path)
+
+## Breaking changes
+- `exploration.exploration_model` -> `exploration.model`
+- `exploration.exploration_endpoint` -> `exploration.endpoint`
+- `exploration.exploration_backend` -> `exploration.backend`
+- `exploration.exploration_api_key` -> `exploration.api_key`
+- removed `exploration.embedding_device` (use `compute.embedding_device`)
+- `intent.skills_loop.enabled` now defaults to `true`
+
+## v0.2.0
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0)_
+
+_No release notes provided._
+
+## v0.2.0-rc.11
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.11)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.10...v0.2.0-rc.11
+
+## v0.2.0-rc.10
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.10)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.9...v0.2.0-rc.10
+
+## v0.2.0-rc.9
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.9)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.8...v0.2.0-rc.9
+
+## v0.2.0-rc.8
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.8)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.7...v0.2.0-rc.8
+
+## v0.2.0-rc.7
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.7)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.6...v0.2.0-rc.7
+
+## v0.2.0-rc.6
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.6)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.5...v0.2.0-rc.6
+
+## v0.2.0-rc.5
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.5)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.4...v0.2.0-rc.5
+
+## v0.2.0-rc.4
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.4)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.3...v0.2.0-rc.4
+
+## v0.2.0-rc.3
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.3)_
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.2...v0.2.0-rc.3
+
+## v0.2.0-rc.2
+
+_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.2)_
+
+## What's Changed
+* chore(security): Scorecard + CodeQL hardening pass by @abolsen in https://github.com/Borgels/vaner/pull/92
+* chore(security): move zizmor ignore to the on: line by @abolsen in https://github.com/Borgels/vaner/pull/93
+* chore(community): add fallback issue template by @abolsen in https://github.com/Borgels/vaner/pull/91
+* fix(ci): repair labels sync and refresh public badges by @abolsen in https://github.com/Borgels/vaner/pull/94
+* chore(community): add .github security policy entry point by @abolsen in https://github.com/Borgels/vaner/pull/95
+* chore(community): expand .github security policy content by @abolsen in https://github.com/Borgels/vaner/pull/97
+* feat: ship local-first gateway and cockpit surfaces by @abolsen in https://github.com/Borgels/vaner/pull/96
+* chore(security): finalize scorecard remediation workflow by @abolsen in https://github.com/Borgels/vaner/pull/98
+* fix(ci): restore scorecard workflow_dispatch trigger by @abolsen in https://github.com/Borgels/vaner/pull/99
+* chore(security): restore pinned dependency + security hardening by @abolsen in https://github.com/Borgels/vaner/pull/101
+* fix(ci): pin VSCode publish workflow for scorecard by @abolsen in https://github.com/Borgels/vaner/pull/102
+* fix(security): close open scanning alerts and doc breakages by @abolsen in https://github.com/Borgels/vaner/pull/103
+* fix(installer): fallback to GitHub source before PyPI publish by @abolsen in https://github.com/Borgels/vaner/pull/104
+* fix(mcp-runtime): harden scenario runtime and cockpit feedback by @abolsen in https://github.com/Borgels/vaner/pull/100
+* feat(mcp): pick backend + ponder cap + MCP-first quickstart by @abolsen in https://github.com/Borgels/vaner/pull/105
+* feat(mcp): friendly backend guard + installer runtime cap UX by @abolsen in https://github.com/Borgels/vaner/pull/106
+* chore(security): gitleaks pre-commit + MCP list_scenarios schema fix by @abolsen in https://github.com/Borgels/vaner/pull/107
+
+
+**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.1.0...v0.2.0-rc.2
+
+## v0.1.0 - initial public release
+
+_Released April 19, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.1.0)_
+
+Initial public release v0.1.0.
+{/* sync:github-releases end */}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "prebuild": "node scripts/emit-mcp-manifest.mjs",
-    "sync:mcp-manifest": "node scripts/emit-mcp-manifest.mjs"
+    "sync:mcp-manifest": "node scripts/emit-mcp-manifest.mjs",
+    "sync:changelog": "node scripts/sync-changelog-from-github.mjs"
   },
   "dependencies": {
     "fumadocs-core": "^16",

--- a/scripts/sync-changelog-from-github.mjs
+++ b/scripts/sync-changelog-from-github.mjs
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+/**
+ * Fetches GitHub releases (paginated), caches the JSON locally, and refreshes the
+ * generated block in content/docs/changelog.mdx.
+ *
+ * Usage:
+ *   node scripts/sync-changelog-from-github.mjs
+ *   node scripts/sync-changelog-from-github.mjs --force
+ *   node scripts/sync-changelog-from-github.mjs --offline
+ *   node scripts/sync-changelog-from-github.mjs --max-cache-age 0
+ *
+ * Env:
+ *   GITHUB_TOKEN — optional; raises API rate limits when set.
+ *
+ * Recommendation: keep this as a manual / CI step (not necessarily every local dev
+ * build) so docs builds stay deterministic offline. Always link to GitHub releases
+ * in the page intro so readers can open issues, assets, and pre-releases.
+ */
+
+import {
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  existsSync,
+} from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const DEFAULT_REPO = 'Borgels/vaner';
+/** MDX-safe markers (HTML comments break the fumadocs-mdx parser). */
+const MARKER_BEGIN = '{/* sync:github-releases begin */}';
+const MARKER_END = '{/* sync:github-releases end */}';
+const USER_AGENT = 'vaner-docs-changelog-sync';
+
+function parseArgs(argv) {
+  let force = false;
+  let offline = false;
+  let maxCacheAgeSec = 86_400; // 24h
+  let repo = DEFAULT_REPO;
+  let cachePath = resolve(repoRoot, 'scripts/.cache/github-releases.json');
+  let changelogPath = resolve(repoRoot, 'content/docs/changelog.mdx');
+
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--force') force = true;
+    else if (a === '--offline') offline = true;
+    else if (a === '--max-cache-age') {
+      maxCacheAgeSec = Number(argv[++i]);
+      if (Number.isNaN(maxCacheAgeSec)) {
+        throw new Error('--max-cache-age needs a number (seconds)');
+      }
+    } else if (a === '--repo') repo = argv[++i];
+    else if (a === '--cache') cachePath = resolve(repoRoot, argv[++i]);
+    else if (a === '--output') changelogPath = resolve(repoRoot, argv[++i]);
+    else if (a === '--help' || a === '-h') {
+      console.log(`Usage: sync-changelog-from-github.mjs [options]
+  --force              Ignore cache age and refetch from GitHub
+  --offline            Only read cache (no HTTP); fails if cache missing
+  --max-cache-age N    Skip refetch if cache is newer than N seconds (default 86400)
+  --repo owner/name    Default ${DEFAULT_REPO}
+  --cache path         Cache file (default scripts/.cache/github-releases.json)
+  --output path        changelog.mdx path (default content/docs/changelog.mdx)
+`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown arg: ${a}`);
+    }
+  }
+
+  return { force, offline, maxCacheAgeSec, repo, cachePath, changelogPath };
+}
+
+function parseNextUrl(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(',')) {
+    const m = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (m) return m[1];
+  }
+  return null;
+}
+
+const FETCH_TIMEOUT_MS = 60_000;
+
+async function fetchAllReleases(repo, token) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': USER_AGENT,
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  const out = [];
+  let url = `https://api.github.com/repos/${repo}/releases?per_page=100`;
+
+  while (url) {
+    const res = await fetch(url, {
+      headers,
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`GitHub API ${res.status}: ${text.slice(0, 500)}`);
+    }
+    const page = await res.json();
+    if (!Array.isArray(page)) {
+      throw new Error(
+        `[sync-changelog] Expected JSON array from GitHub releases API, got ${typeof page}`,
+      );
+    }
+    out.push(...page);
+    url = parseNextUrl(res.headers.get('link'));
+  }
+
+  return out
+    .filter((r) => !r.draft)
+    .sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+}
+
+function formatReleasesMdx(releases, repo) {
+  const releasesUrl = `https://github.com/${repo}/releases`;
+  const lines = [
+    '',
+    `_The section below is generated from [GitHub Releases](${releasesUrl}). Edit release notes on GitHub, then run \`npm run sync:changelog\`._`,
+    '',
+  ];
+
+  for (const r of releases) {
+    const rawTitle = r.name?.trim() || r.tag_name || 'Release';
+    const title = String(rawTitle).replace(/\s+/g, ' ').trim();
+    const date = r.published_at
+      ? new Date(r.published_at).toLocaleDateString('en-US', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        })
+      : '';
+    const badge = r.prerelease ? ' _(pre-release)_' : '';
+    lines.push(`## ${title}${badge}`);
+    lines.push('');
+    lines.push(
+      date
+        ? `_Released ${date} · [View on GitHub](${r.html_url})_`
+        : `_[View on GitHub](${r.html_url})_`,
+    );
+    lines.push('');
+    const body = (r.body || '').trim();
+    lines.push(body || '_No release notes provided._');
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function patchChangelog(changelogPath, generatedInner) {
+  const before = readFileSync(changelogPath, 'utf8');
+  const block = `${MARKER_BEGIN}\n${generatedInner}${MARKER_END}`;
+
+  if (before.includes(MARKER_BEGIN) && before.includes(MARKER_END)) {
+    const next = before.replace(
+      new RegExp(
+        `${escapeRegExp(MARKER_BEGIN)}[\\s\\S]*?${escapeRegExp(MARKER_END)}`,
+      ),
+      block,
+    );
+    writeFileSync(changelogPath, next, 'utf8');
+    return;
+  }
+
+  const appended = `${before.trimEnd()}\n\n${block}\n`;
+  writeFileSync(changelogPath, appended, 'utf8');
+  console.warn(
+    `[sync-changelog] Added ${MARKER_BEGIN}…${MARKER_END} to ${changelogPath}; review placement.`,
+  );
+}
+
+function escapeRegExp(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const args = parseArgs(process.argv);
+const token = process.env.GITHUB_TOKEN;
+
+mkdirSync(dirname(args.cachePath), { recursive: true });
+
+let releases;
+const cacheExists = existsSync(args.cachePath);
+
+function readCachedReleases(cachePath) {
+  const raw = JSON.parse(readFileSync(cachePath, 'utf8'));
+  if (!raw || !Array.isArray(raw.releases)) {
+    throw new Error(
+      `[sync-changelog] Invalid cache at ${cachePath} (missing releases array)`,
+    );
+  }
+  return raw.releases;
+}
+
+if (args.offline) {
+  if (!cacheExists) {
+    throw new Error(
+      `[sync-changelog] --offline but no cache at ${args.cachePath}`,
+    );
+  }
+  releases = readCachedReleases(args.cachePath);
+} else {
+  let useNetwork = args.force || !cacheExists;
+  if (!useNetwork && cacheExists) {
+    const stat = JSON.parse(readFileSync(args.cachePath, 'utf8'));
+    const ageSec = (Date.now() - new Date(stat.fetchedAt).getTime()) / 1000;
+    if (ageSec > args.maxCacheAgeSec) useNetwork = true;
+  }
+
+  if (!useNetwork && cacheExists) {
+    releases = readCachedReleases(args.cachePath);
+    console.log(
+      `[sync-changelog] Using cache (fresh within ${args.maxCacheAgeSec}s).`,
+    );
+  } else {
+    console.log(`[sync-changelog] Fetching releases from GitHub…`);
+    releases = await fetchAllReleases(args.repo, token);
+    writeFileSync(
+      args.cachePath,
+      JSON.stringify(
+        {
+          fetchedAt: new Date().toISOString(),
+          repo: args.repo,
+          releases,
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+    console.log(
+      `[sync-changelog] Cached ${releases.length} releases → ${args.cachePath}`,
+    );
+  }
+}
+
+const inner = formatReleasesMdx(releases, args.repo);
+patchChangelog(args.changelogPath, inner);
+console.log(`[sync-changelog] Updated ${args.changelogPath}`);


### PR DESCRIPTION
## Summary
- **Search:** Add `/api/search` using `createFromSource` so the default Fumadocs search dialog works.
- **UI:** `globals.css` — `overflow-x: visible` on `#nd-docs-layout` for sticky sidebar; theme toggle polish on `#nd-sidebar`.
- **Changelog:** `scripts/sync-changelog-from-github.mjs` (paginated GitHub API, cache, MDX markers) and `npm run sync:changelog`.
- **CI:** New `changelog-sync` job; fails if `content/docs/changelog.mdx` drifts from GitHub Releases. Workflow `permissions: contents: read`.
- **Hardening:** Validate API/cache JSON, 60s fetch timeout, safe JSON error from search route.

## Notes
- Branch protection requires PR + checks; merge after CI passes.

Made with [Cursor](https://cursor.com)