### PR TITLE
polish docs layout and simplify changelog output

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,24 +1,2 @@
 @import 'fumadocs-ui/style.css';
 
-@layer base {
-  /*
-   * Fumadocs uses a sticky sidebar; `overflow-x: clip` on the docs grid can prevent
-   * sticky positioning from behaving correctly in some browsers.
-   */
-  #nd-docs-layout {
-    overflow-x: visible;
-  }
-
-  /*
-   * Sidebar footer merges ThemeSwitch with utility classes that strip rounding;
-   * restore a clear pill toggle so light/dark matches the rest of the UI.
-   */
-  #nd-sidebar [data-theme-toggle] {
-    border-radius: 9999px;
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--color-fd-border);
-    background-color: var(--color-fd-background);
-  }
-}
-

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -10,6 +10,16 @@ Vaner is built around one default architecture:
 - **Side-running ponder engine:** Vaner precomputes scenarios in the background.
 - **Local cockpit controls:** operators inspect, debug, and tune behavior.
 
+## Two loops: precompute and serve
+
+- **Ponder loop (background):** watches repo signals, expands frontier candidates,
+  and refreshes scenario context in storage.
+- **Answer loop (prompt-time):** serves precomputed scenarios over MCP tools when
+  your client asks for context during a real task.
+
+This split is the core performance model: expensive exploration happens between
+prompts, while prompt-time retrieval stays fast and deterministic.
+
 ## Runtime flow
 
 ```mermaid
@@ -66,5 +76,5 @@ See [Cockpit](/cockpit) for the operator view.
 ### Optional gateway capability
 
 `vaner proxy` remains available for clients that only support OpenAI-compatible
-endpoints. It is an advanced compatibility layer, not the default integration
-path.
+endpoints. It is a legacy compatibility layer, not the default integration
+path; prefer MCP-first wiring whenever your client supports MCP.

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -3,184 +3,63 @@ title: Changelog
 description: Notable changes in Vaner documentation and releases.
 ---
 
-Notable product releases are published on [**GitHub Releases**](https://github.com/Borgels/vaner/releases) (downloads, tags, and discussion). The sections below track **docs-only** edits in progress and mirror **published** release notes into this page.
-
-## Unreleased
-
-- Reframed docs around MCP-first architecture: model path via MCP tools by default, with proxy/gateway documented as advanced compatibility mode.
-- Added cockpit/concepts/architecture updates to reflect scenario frontier flow, feedback queue, and operator runtime controls.
-- Clarified product framing: Vaner as a local-first chess engine for next-prompt context prediction.
-- Updated architecture docs to emphasize ponder loop vs answer loop.
-- Expanded integration guidance for proxy, MCP, context-only HTTP, and Python SDK.
-- Added Agent Skills integration docs: skill discovery roots, loop architecture, `vaner distill-skill`, and managed feedback skill flow.
-- Corrected MCP tools list in `/integrations/mcp` to match the actual shipped tool surface.
+Notable product releases are published on [**GitHub Releases**](https://github.com/Borgels/vaner/releases) (downloads, tags, and discussion). This page mirrors published release notes in a short, docs-friendly highlights format.
 
 {/* sync:github-releases begin */}
 
-_The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog`._
+_The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog -- --force`._
 
 ## v0.6.1
 
-_Released April 21, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.1)_
+_Released April 21, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.1)_
 
-## Highlights
-- Fix MCP server startup for stdio/SSE by passing explicit notification capabilities.
-- Restore `vaner config show/keys` stability with intent config compatibility.
-- Add backup-file idempotence and rotation for repeated MCP client wiring.
-- Harden installer MCP dependency resolution and add `vaner uninstall`.
-- Include regression tests and updated installer-first docs/site flows.
-
-See full changelog in `CHANGELOG.md`.
+- Fix MCP server startup for stdio/SSE by passing explicit notification capabilities
+- Restore `vaner config show/keys` stability with intent config compatibility
+- Add backup-file idempotence and rotation for repeated MCP client wiring
+- Harden installer MCP dependency resolution and add `vaner uninstall`
+- Include regression tests and updated installer-first docs/site flows
+- See full changelog in `CHANGELOG.md`
 
 ## v0.6.0
 
-_Released April 21, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.0)_
+_Released April 21, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.6.0)_
 
-## What's Changed
-* fix(ux): harden installer safety, upgrades, and hardware detection by @abolsen in https://github.com/Borgels/vaner/pull/112
-* chore(deps): bump pydantic from 2.13.2 to 2.13.3 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/123
-* chore(deps): bump atheris from 2.3.0 to 3.0.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/121
-* chore(deps): bump pytest-randomly from 4.0.1 to 4.1.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/122
-* chore(deps): bump cyclonedx-bom from 4.6.1 to 7.3.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/120
-* chore(deps): bump sigstore/cosign-installer from 1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 to dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da by @dependabot[bot] in https://github.com/Borgels/vaner/pull/118
-* chore(deps): bump build from 1.2.2.post1 to 1.4.3 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/119
-* chore(deps): bump actions/download-artifact from 4.1.8 to 8.0.1 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/116
-* chore(deps): bump actions/upload-artifact from 4.6.2 to 7.0.1 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/117
-* chore(deps): bump docker/login-action from 3.7.0 to 4.1.0 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/115
-* chore(deps): bump actions/checkout from 4.1.1 to 6.0.2 by @dependabot[bot] in https://github.com/Borgels/vaner/pull/114
-* feat(mcp): v1.0 redesign + first-class memory semantics by @abolsen in https://github.com/Borgels/vaner/pull/113
-
-## New Contributors
-* @dependabot[bot] made their first contribution in https://github.com/Borgels/vaner/pull/123
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.4.0...v0.6.0
+- fix(ux): harden installer safety, upgrades, and hardware detection
+- feat(mcp): v1.0 redesign + first-class memory semantics
 
 ## v0.4.0
 
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.4.0)_
+_Released April 20, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.4.0)_
 
-## Vaner 0.4.0
-
-### Onboarding rescue
-- Added `vaner up` / `vaner down` for a supervised one-command startup and shutdown path.
-- Unified `vaner status` and `vaner doctor` via a shared runtime snapshot for consistent health reporting.
-- Hardened startup reliability with preflight checks (repo-root safety, inotify headroom, busy-port remediation).
-- Added inotify overflow fallback to polling watcher mode instead of crashing.
-- Extended `vaner logs` to include daemon and cockpit runtime logs.
-
-### UX and docs
-- Updated installer next-steps messaging to point users to `vaner up` + `vaner doctor`.
-- Updated README, docs site, and web onboarding callouts for minimal-friction install-to-first-value.
-
-### Quality
-- Full Vaner suite green (245 passing tests) and lint checks clean at release cut.
+- Added `vaner up` / `vaner down` for a supervised one-command startup and shutdown path
+- Unified `vaner status` and `vaner doctor` via a shared runtime snapshot for consistent health reporting
+- Hardened startup reliability with preflight checks (repo-root safety, inotify headroom, busy-port remediation)
+- Added inotify overflow fallback to polling watcher mode instead of crashing
+- Extended `vaner logs` to include daemon and cockpit runtime logs
+- Updated installer next-steps messaging to point users to `vaner up` + `vaner doctor`
+- ...and more on [GitHub](https://github.com/Borgels/vaner/releases/tag/v0.4.0).
 
 ## v0.3.0
 
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.3.0)_
+_Released April 20, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.3.0)_
 
-## Highlights
 - MCP-first skills-loop improvements including scenario feedback plumbing and `vaner distill-skill`
 - CLI UX polish (`--version`, grouped help, config get/keys/edit, aliases, richer doctor output, `vaner upgrade`)
 - Hermetic eval/query core test lane (no sentence-transformers dependency in default CI path)
-
-## Breaking changes
 - `exploration.exploration_model` -> `exploration.model`
 - `exploration.exploration_endpoint` -> `exploration.endpoint`
 - `exploration.exploration_backend` -> `exploration.backend`
-- `exploration.exploration_api_key` -> `exploration.api_key`
-- removed `exploration.embedding_device` (use `compute.embedding_device`)
-- `intent.skills_loop.enabled` now defaults to `true`
+- ...and more on [GitHub](https://github.com/Borgels/vaner/releases/tag/v0.3.0).
 
 ## v0.2.0
 
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0)_
+_Released April 20, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0)_
 
-_No release notes provided._
-
-## v0.2.0-rc.11
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.11)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.10...v0.2.0-rc.11
-
-## v0.2.0-rc.10
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.10)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.9...v0.2.0-rc.10
-
-## v0.2.0-rc.9
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.9)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.8...v0.2.0-rc.9
-
-## v0.2.0-rc.8
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.8)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.7...v0.2.0-rc.8
-
-## v0.2.0-rc.7
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.7)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.6...v0.2.0-rc.7
-
-## v0.2.0-rc.6
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.6)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.5...v0.2.0-rc.6
-
-## v0.2.0-rc.5
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.5)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.4...v0.2.0-rc.5
-
-## v0.2.0-rc.4
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.4)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.3...v0.2.0-rc.4
-
-## v0.2.0-rc.3
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.3)_
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.2.0-rc.2...v0.2.0-rc.3
-
-## v0.2.0-rc.2
-
-_Released April 20, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.2.0-rc.2)_
-
-## What's Changed
-* chore(security): Scorecard + CodeQL hardening pass by @abolsen in https://github.com/Borgels/vaner/pull/92
-* chore(security): move zizmor ignore to the on: line by @abolsen in https://github.com/Borgels/vaner/pull/93
-* chore(community): add fallback issue template by @abolsen in https://github.com/Borgels/vaner/pull/91
-* fix(ci): repair labels sync and refresh public badges by @abolsen in https://github.com/Borgels/vaner/pull/94
-* chore(community): add .github security policy entry point by @abolsen in https://github.com/Borgels/vaner/pull/95
-* chore(community): expand .github security policy content by @abolsen in https://github.com/Borgels/vaner/pull/97
-* feat: ship local-first gateway and cockpit surfaces by @abolsen in https://github.com/Borgels/vaner/pull/96
-* chore(security): finalize scorecard remediation workflow by @abolsen in https://github.com/Borgels/vaner/pull/98
-* fix(ci): restore scorecard workflow_dispatch trigger by @abolsen in https://github.com/Borgels/vaner/pull/99
-* chore(security): restore pinned dependency + security hardening by @abolsen in https://github.com/Borgels/vaner/pull/101
-* fix(ci): pin VSCode publish workflow for scorecard by @abolsen in https://github.com/Borgels/vaner/pull/102
-* fix(security): close open scanning alerts and doc breakages by @abolsen in https://github.com/Borgels/vaner/pull/103
-* fix(installer): fallback to GitHub source before PyPI publish by @abolsen in https://github.com/Borgels/vaner/pull/104
-* fix(mcp-runtime): harden scenario runtime and cockpit feedback by @abolsen in https://github.com/Borgels/vaner/pull/100
-* feat(mcp): pick backend + ponder cap + MCP-first quickstart by @abolsen in https://github.com/Borgels/vaner/pull/105
-* feat(mcp): friendly backend guard + installer runtime cap UX by @abolsen in https://github.com/Borgels/vaner/pull/106
-* chore(security): gitleaks pre-commit + MCP list_scenarios schema fix by @abolsen in https://github.com/Borgels/vaner/pull/107
-
-
-**Full Changelog**: https://github.com/Borgels/vaner/compare/v0.1.0...v0.2.0-rc.2
+- See details on GitHub.
 
 ## v0.1.0 - initial public release
 
-_Released April 19, 2026 · [View on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.1.0)_
+_Released April 19, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.1.0)_
 
-Initial public release v0.1.0.
+- Initial public release v0.1.0
 {/* sync:github-releases end */}

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -17,38 +17,13 @@ first and install the full CLI later only if you want it. Three steps:
 2. Pick the model backend Vaner should ponder with.
 3. Use the MCP tools from your AI client.
 
-## 1. Install Vaner
+## 1. Install once, then wire clients
 
-> [!NOTE]
-> The default snippets use `uvx`, which requires `uv` on your PATH. Install it
-> from [docs.astral.sh/uv](https://docs.astral.sh/uv/getting-started/installation/).
-> If `uvx --from "vaner[mcp]" ...` cannot resolve from PyPI yet, use the
-> generated GitHub source spec snippet or switch launcher mode to `path` after
-> running the installer.
+Install instructions live in [Getting Started](/getting-started), including
+interactive and non-interactive installer modes, environment variable mirrors,
+and source install fallback.
 
-> [!TIP]
-> Running Vaner via MCP (`uvx ... vaner mcp`) starts the MCP server process on
-> demand, but does **not** auto-start Ollama/model pulls or background daemon
-> precompute.
-
-```bash
-curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
-```
-
-The installer:
-
-- Ships the `[mcp]` extra by default so `vaner mcp` works immediately.
-- Falls back to `git+https://github.com/Borgels/vaner.git` if the PyPI wheel isn't available yet.
-- Asks you to pick a backend and a compute profile (interactive TTY). Pass
-  `--yes --backend-preset <id> --compute-preset <id>` for non-interactive installs.
-
-Smoke-test the server from a terminal:
-
-```bash
-vaner init --path .
-vaner mcp --path .
-# Ctrl+C when you see "MCP server ready"
-```
+Use this page for MCP wiring after install.
 
 ## 2. Pick a model backend
 
@@ -67,6 +42,46 @@ Pick your client, copy the snippet, restart the app, and call `list_scenarios`
 to verify.
 
 <McpClientPicker />
+
+## What `vaner init` writes
+
+`vaner init --path .` is the recommended path for most users because it can
+configure MCP clients and managed skill guidance in one pass.
+
+### MCP client wiring
+
+Vaner writes or updates only the `vaner` MCP server entry for supported clients
+(Cursor, Claude Desktop, Claude Code, VS Code Copilot, Codex CLI, Windsurf,
+Zed, Continue, Cline, and Roo Code), using the same snippets shown by the
+picker on this page.
+
+Common paths include:
+
+- `~/.cursor/mcp.json` or `.cursor/mcp.json`
+- `~/.config/Code/User/mcp.json` or `.vscode/mcp.json`
+- `~/.codex/config.toml` (via `codex mcp add`)
+- `~/.codeium/windsurf/mcp_config.json`
+- `~/.config/zed/settings.json`
+- `~/.continue/mcpServers/vaner.yaml` or `.continue/mcpServers/vaner.yaml`
+- `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- `~/.roo/mcp_settings.json` or `.roo/mcp.json`
+
+### Safety and rollback behavior
+
+- Writes are idempotent: rerunning `vaner init` updates the same `vaner` entry.
+- Existing configs are backed up (`.bak` rotation) before mutation.
+- You can remove managed wiring with `vaner uninstall`.
+
+### Managed prompt update via `vaner-feedback` skill
+
+`vaner init` can install a managed `vaner-feedback` skill under:
+
+- `.cursor/skills/vaner/vaner-feedback/SKILL.md`
+- `.claude/skills/vaner/vaner-feedback/SKILL.md`
+
+This is effectively a system-prompt-level instruction for agent runtimes: after
+using Vaner scenarios, report outcomes back via `report_outcome` so ranking can
+improve over time. See [Agent Skills](/skills) for the full loop.
 
 ## Optional: bound ponder time
 

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "index",
     "getting-started",
+    "usage",
     "troubleshooting",
     "mcp",
     "skills",

--- a/content/docs/usage.mdx
+++ b/content/docs/usage.mdx
@@ -1,0 +1,57 @@
+---
+title: Usage
+description: Day-to-day Vaner workflow with MCP tools, background pondering, and feedback loops.
+---
+
+Vaner works best when you treat it as a continuously learning context service for
+your repo: keep it running during active sessions, call MCP tools when needed,
+and report outcomes so ranking improves over time.
+
+## Daily workflow
+
+```bash
+vaner up --path .
+vaner status --path .
+# work in your client with Vaner MCP tools
+vaner down --path .
+```
+
+- `vaner up` starts the supervised runtime (daemon + cockpit).
+- `vaner status` confirms health and runtime details.
+- `vaner down` cleanly stops the background processes.
+
+If behavior seems off, run:
+
+```bash
+vaner doctor --path .
+```
+
+## How MCP usage fits in
+
+During a coding session, your client calls Vaner MCP tools such as:
+
+- `list_scenarios`
+- `get_scenario`
+- `expand_scenario`
+- `compare_scenarios`
+- `report_outcome`
+
+Vaner serves prepared scenario context from the local store and keeps refining
+future ranking with outcome feedback.
+
+## Ponder loop vs answer loop
+
+- **Ponder loop (background):** precomputes and refreshes scenario candidates.
+- **Answer loop (prompt-time):** serves and ranks scenarios when the client asks.
+
+This split is why Vaner can stay responsive during prompts while still doing
+deeper exploration between prompts.
+
+## Managed skill prompts and feedback
+
+When you run `vaner init`, Vaner can install a managed `vaner-feedback` skill in
+supported client skill roots. That skill acts as system-prompt guidance so the
+agent reports outcome quality (`useful`, `partial`, `irrelevant`) after it uses
+Vaner scenarios.
+
+That closed loop improves which scenarios are ranked first in later sessions.

--- a/scripts/sync-changelog-from-github.mjs
+++ b/scripts/sync-changelog-from-github.mjs
@@ -121,13 +121,16 @@ async function fetchAllReleases(repo, token) {
 
 function formatReleasesMdx(releases, repo) {
   const releasesUrl = `https://github.com/${repo}/releases`;
+  const visibleReleases = releases.filter(
+    (r) => !r.prerelease && !/-((rc|beta|alpha)[\d.-]*)$/i.test(r.tag_name || ''),
+  );
   const lines = [
     '',
-    `_The section below is generated from [GitHub Releases](${releasesUrl}). Edit release notes on GitHub, then run \`npm run sync:changelog\`._`,
+    `_The section below is generated from [GitHub Releases](${releasesUrl}). Edit release notes on GitHub, then run \`npm run sync:changelog -- --force\`._`,
     '',
   ];
 
-  for (const r of releases) {
+  for (const r of visibleReleases) {
     const rawTitle = r.name?.trim() || r.tag_name || 'Release';
     const title = String(rawTitle).replace(/\s+/g, ' ').trim();
     const date = r.published_at
@@ -137,21 +140,78 @@ function formatReleasesMdx(releases, repo) {
           day: 'numeric',
         })
       : '';
-    const badge = r.prerelease ? ' _(pre-release)_' : '';
-    lines.push(`## ${title}${badge}`);
+    lines.push(`## ${title}`);
     lines.push('');
     lines.push(
       date
-        ? `_Released ${date} · [View on GitHub](${r.html_url})_`
-        : `_[View on GitHub](${r.html_url})_`,
+        ? `_Released ${date} · [Details on GitHub](${r.html_url})_`
+        : `_[Details on GitHub](${r.html_url})_`,
     );
     lines.push('');
-    const body = (r.body || '').trim();
-    lines.push(body || '_No release notes provided._');
+    const body = extractHighlights(r.body || '', r.html_url);
+    lines.push(...body.map((item) => `- ${item}`));
     lines.push('');
   }
 
   return `${lines.join('\n').trimEnd()}\n`;
+}
+
+const MAX_HIGHLIGHTS = 6;
+const HEADER_RE = /^#{1,6}\s+/;
+const FULL_CHANGELOG_RE = /^\*\*full changelog\*\*:\s*/i;
+const SECTION_HEADING_RE = /^##?\s*(highlights|what'?s changed|new contributors)\s*$/i;
+const DEPENDABOT_RE = /\bdependabot\b/i;
+const CHORE_DEPS_RE = /\bchore\(deps\)\b/i;
+const NO_NOTES_RE = /^_?no release notes provided\.?_?$/i;
+const PR_ATTRIBUTION_RE = /\s+by\s+@[\w-]+\s+in\s+https?:\/\/\S+\s*$/i;
+
+function normalizeHighlight(text) {
+  return text
+    .replace(/^\s*[-*]\s+/, '')
+    .replace(PR_ATTRIBUTION_RE, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\.$/, '');
+}
+
+function shouldSkipLine(line) {
+  if (!line) return true;
+  if (HEADER_RE.test(line)) return true;
+  if (SECTION_HEADING_RE.test(line)) return true;
+  if (FULL_CHANGELOG_RE.test(line)) return true;
+  if (NO_NOTES_RE.test(line)) return true;
+  if (DEPENDABOT_RE.test(line)) return true;
+  if (CHORE_DEPS_RE.test(line)) return true;
+  return false;
+}
+
+function extractHighlights(body, releaseUrl) {
+  const candidates = [];
+  let inFence = false;
+
+  for (const rawLine of body.split('\n')) {
+    const trimmed = rawLine.trim();
+    if (trimmed.startsWith('```')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence || shouldSkipLine(trimmed)) continue;
+
+    const normalized = normalizeHighlight(trimmed);
+    if (!normalized) continue;
+    candidates.push(normalized);
+  }
+
+  const deduped = [...new Set(candidates)];
+  if (deduped.length === 0) return ['See details on GitHub.'];
+
+  if (deduped.length > MAX_HIGHLIGHTS) {
+    return [
+      ...deduped.slice(0, MAX_HIGHLIGHTS),
+      `...and more on [GitHub](${releaseUrl}).`,
+    ];
+  }
+  return deduped;
 }
 
 function patchChangelog(changelogPath, generatedInner) {


### PR DESCRIPTION
## Summary
- restore Fumadocs default sidebar/theme behavior by removing custom global overrides
- simplify release-note rendering by filtering prereleases and condensing GitHub release bodies into highlight bullets
- update docs content with a new usage page, MCP init wiring details, and clearer architecture loop framing

## Test plan
- [x] npm run sync:changelog -- --force
- [x] npm run build

Made with [Cursor](https://cursor.com)