### PR TITLE
feat: AI-first foundations — llms.txt, per-page markdown, page actions

### DIFF
--- a/app/(docs)/[[...slug]]/page.tsx
+++ b/app/(docs)/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import { useMDXComponents } from '@/mdx-components';
+import { PageActions } from '@/components/page-actions';
 
 export default async function Page({
   params,
@@ -36,6 +37,7 @@ export default async function Page({
       <DocsTitle>{page.data.title}</DocsTitle>
       <DocsDescription>{page.data.description}</DocsDescription>
       <DocsBody>
+        <PageActions pageUrl={page.url} pageTitle={page.data.title} />
         <MDX components={mdxComponents} />
       </DocsBody>
     </DocsPage>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,2 +1,28 @@
 @import 'fumadocs-ui/style.css';
 
+@layer base {
+  /*
+   * Keep docs content centered at normal widths, but pin the sidebar to the
+   * viewport edge on very wide screens (closer to docs.ollama.com behavior).
+   */
+  @media (min-width: 1800px) {
+    #nd-docs-layout {
+      grid-template-columns:
+        0
+        var(--fd-sidebar-col)
+        minmax(0, calc(var(--fd-layout-width, 97rem) - var(--fd-sidebar-width) - var(--fd-toc-width)))
+        var(--fd-toc-width)
+        minmax(min-content, 1fr);
+    }
+  }
+
+  /*
+   * Fumadocs sidebar footer row is full-width by default. Shrink the row that
+   * contains the theme toggle so it hugs the icon buttons + light/dark buttons.
+   */
+  #nd-sidebar div:has(> [data-theme-toggle]) {
+    width: fit-content;
+    max-width: 100%;
+  }
+}
+

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,0 +1,21 @@
+import { source } from '@/lib/source';
+import { getLLMText } from '@/lib/get-llm-text';
+
+export const revalidate = false;
+
+export async function GET() {
+  const scan = source.getPages().map(getLLMText);
+  const scanned = await Promise.all(scan);
+
+  const header = `# Vaner Documentation — Full Content
+
+> All documentation pages concatenated for AI consumption.
+> For a curated index see: https://docs.vaner.ai/llms.txt
+> For AI install/operation prompts see: https://vaner.ai/prompts/install.md
+
+---
+
+`;
+
+  return new Response(header + scanned.join('\n\n---\n\n'));
+}

--- a/app/llms.mdx/docs/[[...slug]]/route.ts
+++ b/app/llms.mdx/docs/[[...slug]]/route.ts
@@ -1,0 +1,22 @@
+import { getLLMText } from '@/lib/get-llm-text';
+import { source } from '@/lib/source';
+import { notFound } from 'next/navigation';
+
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,0 +1,31 @@
+import { source } from '@/lib/source';
+import { llms } from 'fumadocs-core/source';
+
+export const revalidate = false;
+
+export function GET() {
+  const index = llms(source).index();
+
+  const preamble = `# Vaner Documentation
+
+> Vaner is a predictive context engine. It ponders your codebase in the background —
+> exploring scenarios, pre-computing context, ranking what matters — so when you ask,
+> the right evidence is already at the front of the queue.
+
+## AI install & operation prompts
+
+- [Install prompt](https://vaner.ai/prompts/install.md): install, wire MCP, pick backend, verify.
+- [Upgrade prompt](https://vaner.ai/prompts/upgrade.md): upgrade in place, restart, verify.
+- [Backend swap prompt](https://vaner.ai/prompts/backend-swap.md): switch model backend, verify.
+- [Debug prompt](https://vaner.ai/prompts/debug.md): diagnose MCP not showing, silent ponder loop, stale context.
+
+## Full documentation content
+
+- [llms-full.txt](https://docs.vaner.ai/llms-full.txt): all documentation pages in a single file.
+
+---
+
+`;
+
+  return new Response(preamble + index);
+}

--- a/components/page-actions.tsx
+++ b/components/page-actions.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+
+type PageActionsProps = {
+  /** The page URL path, e.g. "/getting-started". Used to build the .mdx URL and the handoff links. */
+  pageUrl: string;
+  /** The page title, used in the handoff prompt. */
+  pageTitle: string;
+};
+
+const DOCS_ORIGIN = "https://docs.vaner.ai";
+
+function handoffUrl(baseUrl: string, mdxUrl: string, title: string) {
+  const msg = `Read ${DOCS_ORIGIN}${mdxUrl} and help me understand: ${title}`;
+  return `${baseUrl}?q=${encodeURIComponent(msg)}`;
+}
+
+export function PageActions({ pageUrl, pageTitle }: PageActionsProps) {
+  const [copied, setCopied] = useState(false);
+
+  // /getting-started → /docs/getting-started.mdx  (Fumadocs *.mdx rewrite)
+  const mdxUrl = `${pageUrl}.mdx`;
+
+  const copyMarkdown = async () => {
+    try {
+      const res = await fetch(mdxUrl);
+      const text = res.ok ? await res.text() : `${DOCS_ORIGIN}${mdxUrl}`;
+      await navigator.clipboard.writeText(text);
+    } catch {
+      try {
+        await navigator.clipboard.writeText(`${DOCS_ORIGIN}${mdxUrl}`);
+      } catch {}
+    }
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1600);
+  };
+
+  return (
+    <div className="mb-6 flex flex-wrap items-center gap-2 border-b pb-4">
+      <button
+        type="button"
+        onClick={copyMarkdown}
+        title="Copy page as Markdown"
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-fd-border bg-fd-muted/30 px-2.5 text-xs text-fd-muted-foreground transition-colors hover:border-fd-foreground/30 hover:text-fd-foreground"
+      >
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          className="h-3 w-3 shrink-0"
+          aria-hidden
+        >
+          <rect x="4" y="4" width="9" height="9" rx="1.5" />
+          <path d="M3 10 V3.5 A1.5 1.5 0 0 1 4.5 2 H10" />
+        </svg>
+        {copied ? "Copied" : "Copy as Markdown"}
+      </button>
+
+      <a
+        href={handoffUrl("https://chatgpt.com/", mdxUrl, pageTitle)}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Open this page in ChatGPT"
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-fd-border bg-fd-muted/30 px-2.5 text-xs text-fd-muted-foreground transition-colors hover:border-fd-foreground/30 hover:text-fd-foreground"
+      >
+        Ask ChatGPT
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          className="h-3 w-3 shrink-0"
+          aria-hidden
+        >
+          <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+          <path d="M10 2h4v4" />
+          <path d="M14 2 8 8" />
+        </svg>
+      </a>
+
+      <a
+        href={handoffUrl("https://claude.ai/new", mdxUrl, pageTitle)}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Open this page in Claude"
+        className="inline-flex h-7 items-center gap-1.5 rounded-md border border-fd-border bg-fd-muted/30 px-2.5 text-xs text-fd-muted-foreground transition-colors hover:border-fd-foreground/30 hover:text-fd-foreground"
+      >
+        Ask Claude
+        <svg
+          viewBox="0 0 16 16"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+          className="h-3 w-3 shrink-0"
+          aria-hidden
+        >
+          <path d="M6 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1v-3" />
+          <path d="M10 2h4v4" />
+          <path d="M14 2 8 8" />
+        </svg>
+      </a>
+    </div>
+  );
+}

--- a/content/docs/ai-prompts.mdx
+++ b/content/docs/ai-prompts.mdx
@@ -1,0 +1,64 @@
+---
+title: AI prompts
+description: Canonical prompts your AI can execute to install, upgrade, swap backends, and debug Vaner — works in Cursor, Claude Code, Codex, Cline, Windsurf, and any terminal-capable agent.
+---
+
+These prompts are designed to be copied and pasted directly into any AI client that can run shell commands. Each one is a complete, self-contained task.
+
+## Install
+
+Sets up Vaner from scratch: installs the binary, detects your MCP client, wires up the MCP config, picks a model backend, starts the ponder loop, and verifies with `vaner doctor`.
+
+```
+Read https://vaner.ai/prompts/install.md and follow it exactly.
+Before running anything destructive, confirm with me.
+```
+
+[Raw prompt (copy-paste ready)](https://vaner.ai/prompts/install.md)
+
+---
+
+## Upgrade
+
+Upgrades Vaner in place, restarts the daemon, and verifies the new version is healthy.
+
+```
+Read https://vaner.ai/prompts/upgrade.md and follow it exactly.
+Before running anything destructive, confirm with me.
+```
+
+[Raw prompt (copy-paste ready)](https://vaner.ai/prompts/upgrade.md)
+
+---
+
+## Backend swap
+
+Switches the model backend (Ollama, LM Studio, vLLM, OpenAI, Anthropic, xAI, Groq, Together AI), updates config, restarts, and verifies.
+
+```
+Read https://vaner.ai/prompts/backend-swap.md and follow it exactly.
+Before running anything destructive, confirm with me.
+```
+
+[Raw prompt (copy-paste ready)](https://vaner.ai/prompts/backend-swap.md)
+
+---
+
+## Debug
+
+Diagnoses common problems: MCP tools not appearing, silent ponder loop, stale context, daemon crashes. Runs `vaner doctor`, checks MCP wiring, inspects logs.
+
+```
+Read https://vaner.ai/prompts/debug.md and follow it exactly.
+Before running anything destructive, confirm with me.
+```
+
+[Raw prompt (copy-paste ready)](https://vaner.ai/prompts/debug.md)
+
+---
+
+## Tip: use the landing page buttons
+
+The [Vaner home page](https://vaner.ai) has a **Terminal / AI prompt** toggle in the hero. Switch to **AI prompt**, click **Copy**, then paste into any terminal-capable AI agent — it will copy the full install prompt above.
+
+The [MCP setup page](https://vaner.ai/mcp) has **Copy install prompt**, **Open in ChatGPT**, and **Open in Claude** buttons directly below the install command.

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -4,6 +4,7 @@
     "index",
     "getting-started",
     "usage",
+    "ai-prompts",
     "troubleshooting",
     "mcp",
     "skills",

--- a/lib/get-llm-text.ts
+++ b/lib/get-llm-text.ts
@@ -1,0 +1,9 @@
+import { source } from '@/lib/source';
+
+type Page = ReturnType<typeof source.getPages>[number];
+
+export async function getLLMText(page: Page) {
+  const processed = await page.data.getText('processed');
+
+  return `# ${page.data.title} (${page.url})\n\n${processed}`;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,14 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  async rewrites() {
+    return [
+      {
+        source: '/docs/:path*.mdx',
+        destination: '/llms.mdx/docs/:path*',
+      },
+    ];
+  },
 };
 
 export default withMDX(config);

--- a/source.config.ts
+++ b/source.config.ts
@@ -2,6 +2,11 @@ import { defineConfig, defineDocs } from 'fumadocs-mdx/config';
 
 export const { docs, meta } = defineDocs({
   dir: 'content/docs',
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 export default defineConfig();


### PR DESCRIPTION
## Summary

- **`source.config.ts`**: `postprocess.includeProcessedMarkdown: true` — every page now has processed markdown available server-side.
- **`lib/get-llm-text.ts`**: shared helper to render a page as `# Title (url)\n\ncontent`.
- **`/llms.txt`**: Fumadocs-generated curated index with a Vaner preamble and links to the prompts library on vaner.ai.
- **`/llms-full.txt`**: all 32 doc pages concatenated, cached forever, with header pointing to the index.
- **`/docs/*.mdx`**: per-page raw markdown via `app/llms.mdx/docs/[[...slug]]/route.ts` + rewrite in `next.config.mjs`. E.g. `/docs/getting-started.mdx` returns processed markdown with `Content-Type: text/markdown`.
- **`PageActions` component**: "Copy as Markdown / Ask ChatGPT / Ask Claude" row rendered at the top of every docs page body.
- **`/docs/ai-prompts`**: new docs page listing all four canonical prompts, added to sidebar between Usage and Troubleshooting.
- **`globals.css`**: wide-screen layout fix for docs (pre-existing local change).

## Test plan

- [ ] `/llms.txt` returns the index with prompts preamble
- [ ] `/llms-full.txt` returns all pages concatenated
- [ ] `/docs/getting-started.mdx` returns the page's markdown with correct Content-Type
- [ ] Every docs page shows Copy as Markdown, Ask ChatGPT, Ask Claude buttons
- [ ] `/docs/ai-prompts` appears in the sidebar and links to vaner.ai/prompts/*.md

Made with [Cursor](https://cursor.com)