### PR TITLE
docs(integrations): 0.8.5 integration-layer + MCP Apps UI pages

### DIFF
--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -217,8 +217,8 @@ tracked in the desktop repo's issues.
 
 Platform-specific issues belong in the platform repo:
 
-- macOS: <https://github.com/Borgels/vaner-desktop-macos/issues>
-- Linux: <https://github.com/Borgels/vaner-desktop-linux/issues>
+- macOS: [github.com/Borgels/vaner-desktop-macos/issues](https://github.com/Borgels/vaner-desktop-macos/issues)
+- Linux: [github.com/Borgels/vaner-desktop-linux/issues](https://github.com/Borgels/vaner-desktop-linux/issues)
 
 Engine or skill issues (including `/vaner:next` behaviour) go to the
 main [Vaner repo](https://github.com/Borgels/Vaner/issues).

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -46,48 +46,60 @@ open vaner.xcodeproj
 
 ### Linux (Ubuntu / Debian)
 
-Signed `.deb`. The one-liner below downloads the latest release,
-verifies its detached signature against Vaner's release pubkey
-(whose fingerprint is pinned in the install script itself), and
-installs via `apt`. If the uploaded pubkey's fingerprint ever gets
-swapped, the script aborts with a mismatch error rather than trust
-an unknown signer.
+Three paths, all signed against release key fingerprint
+`506B8FA959917D530E5EE7203D219B47A7E4F046`. Pick one.
+
+**Recommended — apt repository with auto-updates.** Registers a
+signed apt source; subsequent releases arrive through
+`apt upgrade`.
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/scripts/install.sh | bash
 ```
 
-Prefer to read the script before piping it? Fair.
+Or the plain-apt form, no pipe-to-bash:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/scripts/install.sh \
-  -o vaner-install.sh
-less vaner-install.sh   # cross-check the VANER_RELEASE_FPR pin
-bash vaner-install.sh
+curl -fsSL https://borgels.github.io/vaner-desktop-linux/release-key.asc \
+  | sudo gpg --dearmor -o /etc/apt/keyrings/vaner.gpg
+echo "deb [signed-by=/etc/apt/keyrings/vaner.gpg] https://borgels.github.io/vaner-desktop-linux stable main" \
+  | sudo tee /etc/apt/sources.list.d/vaner.list
+sudo apt update && sudo apt install vaner-desktop-linux
 ```
 
-Manual verify-then-install (gpg only, no script):
+**One-off `.deb`** (no apt registration):
+
+```bash
+VANER_MODE=deb curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/scripts/install.sh | bash
+```
+
+**`.AppImage`** — portable, no install:
 
 ```bash
 VER=$(curl -fsSL https://api.github.com/repos/Borgels/vaner-desktop-linux/releases/latest | jq -r .tag_name)
-curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner_${VER#v}_amd64.deb
-curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner_${VER#v}_amd64.deb.asc
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/Vaner_${VER#v}_amd64.AppImage
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/Vaner_${VER#v}_amd64.AppImage.asc
 curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/release-key.asc
-
 gpg --import release-key.asc
-gpg --verify vaner_${VER#v}_amd64.deb.asc vaner_${VER#v}_amd64.deb
-sudo apt install ./vaner_${VER#v}_amd64.deb
-```
-
-Then launch from your app menu, or:
-
-```bash
-vaner-desktop-linux
+gpg --verify Vaner_${VER#v}_amd64.AppImage.asc Vaner_${VER#v}_amd64.AppImage
+chmod +x Vaner_${VER#v}_amd64.AppImage && ./Vaner_${VER#v}_amd64.AppImage
 ```
 
 Target: Ubuntu 22.04+ / Debian 12+, X11 or KDE Plasma (Wayland and X11
 both fine). See the [first-run note below](#gnome-on-wayland-tray-icon) if
 you're on stock GNOME under Wayland.
+
+#### Auto-updates
+
+The desktop checks for new releases on every launch (via
+[`tauri-plugin-updater`](https://v2.tauri.app/plugin/updater/)). Every
+update is signed with a dedicated minisign key whose public half is
+compiled into the app — a tampered update fails verification and is
+silently discarded. When a new release is ready, a small banner
+appears in the popover; click **Install** to download + verify + swap
+in place (no shell required). Users on the apt repo path get the
+same updates through their system's normal upgrade flow instead —
+pick one mechanism, not both.
 
 Dev build from source:
 

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -84,12 +84,12 @@ VANER_MODE=deb curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-deskto
 
 ```bash
 VER=$(curl -fsSL https://api.github.com/repos/Borgels/vaner-desktop-linux/releases/latest | jq -r .tag_name)
-curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/Vaner_${VER#v}_amd64.AppImage
-curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/Vaner_${VER#v}_amd64.AppImage.asc
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner-desktop_${VER#v}_amd64.AppImage
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner-desktop_${VER#v}_amd64.AppImage.asc
 curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/release-key.asc
 gpg --import release-key.asc
-gpg --verify Vaner_${VER#v}_amd64.AppImage.asc Vaner_${VER#v}_amd64.AppImage
-chmod +x Vaner_${VER#v}_amd64.AppImage && ./Vaner_${VER#v}_amd64.AppImage
+gpg --verify vaner-desktop_${VER#v}_amd64.AppImage.asc vaner-desktop_${VER#v}_amd64.AppImage
+chmod +x vaner-desktop_${VER#v}_amd64.AppImage && ./vaner-desktop_${VER#v}_amd64.AppImage
 ```
 
 Target: Ubuntu 22.04+ / Debian 12+, X11 or KDE Plasma (Wayland and X11

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -1,0 +1,178 @@
+---
+title: Desktop app
+description: Vaner's menu-bar companion for macOS and Linux — install, first-run, and the Adopt flow for handing prepared context to your AI agent.
+---
+
+Vaner is primarily an engine your AI agent (Claude Code, Cursor, Zed,
+Claude Desktop, …) talks to over MCP. But while it's running in the
+background, it's also pondering — ranking likely next prompts, staging
+evidence, drafting answers. The desktop app is a small menu-bar
+companion that lets **you** see what Vaner has pondered and click one
+thing to inject the prepared package into whichever agent you're using.
+
+Two clients, same engine:
+
+| Platform | Repo | Native stack |
+|---|---|---|
+| **macOS** | [`Borgels/vaner-desktop-macos`](https://github.com/Borgels/vaner-desktop-macos) | SwiftUI + AppKit, menu-bar popover |
+| **Linux** (Ubuntu / Debian / KDE / GNOME) | [`Borgels/vaner-desktop-linux`](https://github.com/Borgels/vaner-desktop-linux) | Tauri v2 + SvelteKit, tray + popover |
+| Windows | Planned | Tauri v2 (same codebase as Linux) |
+
+Both apps talk only **HTTP / SSE** to the local Vaner daemon on
+`127.0.0.1:8473`. They never speak MCP themselves — that's reserved
+for your AI agent.
+
+## Install
+
+### macOS
+
+> The engine must be running first. Install Vaner and start the daemon
+> following [Getting Started](./getting-started.mdx); the desktop app
+> attaches to whatever's up on `127.0.0.1:8473`.
+
+Grab the latest `.dmg` from the [macOS releases page](https://github.com/Borgels/vaner-desktop-macos/releases),
+mount it, and drag **Vaner.app** into `/Applications`. On first
+launch, macOS may ask you to verify the app via System Settings →
+Privacy & Security. Once open, Vaner lives in your menu bar — click
+the icon to pop the popover.
+
+If you prefer to build from source:
+
+```bash
+git clone https://github.com/Borgels/vaner-desktop-macos.git
+cd vaner-desktop-macos
+open vaner.xcodeproj
+```
+
+### Linux (Ubuntu / Debian)
+
+```bash
+# Grab the latest .deb from the Linux releases page
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/latest/download/vaner_latest_amd64.deb
+sudo apt install ./vaner_latest_amd64.deb
+```
+
+Then launch from your app menu, or:
+
+```bash
+vaner-desktop-linux
+```
+
+Target: Ubuntu 22.04+ / Debian 12+, X11 or KDE Plasma (Wayland and X11
+both fine). See the [first-run note below](#gnome-on-wayland-tray-icon) if
+you're on stock GNOME under Wayland.
+
+Dev build from source:
+
+```bash
+# One-time system deps
+sudo apt install -y libwebkit2gtk-4.1-dev libgtk-3-dev \
+  libayatana-appindicator3-dev librsvg2-dev patchelf
+
+git clone https://github.com/Borgels/vaner-desktop-linux.git
+cd vaner-desktop-linux
+pnpm install
+pnpm tauri dev
+```
+
+## What the popover shows
+
+The desktop app mirrors whatever state the engine is in. Five common
+states you'll see:
+
+| State | Meaning |
+|---|---|
+| **Watching** | Daemon is alive, sources are connected, nothing surfaceable yet. |
+| **Learning** | First-time indexing — Vaner is reading the sources you just connected. |
+| **Prepared** | A reactive prepared moment is ready (based on something you already did). |
+| **Active predictions** | Vaner has one or more predicted next-prompts in `drafting` / `ready`. Click **Adopt** on any row to send its full prepared package to your agent. |
+| **No active agent** | Predictions or prepared moments exist, but Vaner doesn't see your agent running. Launch Cursor / Claude Code / etc. and the popover will re-route. |
+
+## The Adopt flow
+
+When you click **Adopt** on a ready prediction row, here's what
+happens:
+
+1. The app calls `POST /predictions/{id}/adopt` on the local daemon.
+   The daemon returns a `Resolution` — the full prepared package:
+   briefing, optional predicted-response draft, evidence,
+   alternatives considered.
+2. The app writes that `Resolution` to a **handoff file** at a
+   well-known path:
+   - Linux: `$XDG_STATE_HOME/vaner/pending-adopt.json`
+     (usually `~/.local/state/vaner/pending-adopt.json`).
+   - macOS: `~/Library/Application Support/Vaner/pending-adopt.json`.
+3. The paste-fallback (`predicted_response ?? prepared_briefing ??
+   intent`) goes onto your clipboard, in case you want to paste it
+   into an agent that doesn't support the handoff yet.
+4. Your agent's next turn reads the handoff file.
+   - In Claude Code, the [`/vaner:next` skill](./skills.mdx) checks
+     this path before anything else; if a fresh drop is there
+     (< 10 minutes old), it injects the prepared package directly and
+     skips the listing step.
+   - Agents without a Vaner skill can paste the clipboard content
+     manually.
+
+This is how the desktop and your agent compose — you decide in the
+popover, the agent serves it on the next turn.
+
+## First-run notes
+
+### GNOME on Wayland: tray icon
+
+GNOME Shell on Wayland doesn't render `AppIndicator`-style tray icons
+by default. Ubuntu 22.04+ ships the extension that fixes this; vanilla
+GNOME or a stripped-down session may not.
+
+If the Linux app's tray icon doesn't appear, install the extension:
+
+```bash
+sudo apt install gnome-shell-extension-appindicator
+# Log out + back in, or: `killall -HUP gnome-shell` on X11 only
+```
+
+The app detects this at first launch and shows a one-time modal with
+these exact instructions — no guessing. KDE Plasma and X11 sessions
+don't need the extension.
+
+### Global shortcuts on Wayland
+
+The Wayland protocol doesn't expose a system-wide-hotkey API. If the
+app gracefully disables its global-shortcut features on your session,
+that's why. X11 supports them; so does macOS.
+
+### macOS sandboxing
+
+Release macOS builds are sandboxed. The adopt-handoff file currently
+requires an unsandboxed build OR a one-time "choose a folder" dialog
+that persists via a security-scoped bookmark. DEBUG builds are
+unsandboxed and work out of the box; the v1 sandboxed release is
+tracked in the desktop repo's issues.
+
+## Troubleshooting
+
+- **Popover says "Can't reach the Vaner engine."** Check the daemon:
+  ```bash
+  vaner status --json
+  ```
+  If it's stopped, run `vaner up`. The desktop attaches automatically
+  on its next refresh tick.
+- **Predictions never appear.** This is often expected — Vaner needs
+  a few minutes of observation and at least one MCP call before the
+  prediction layer has something to surface. Keep working; the
+  popover updates itself.
+- **Adopt seems to do nothing in my agent.** Make sure your agent
+  invokes the Vaner skill (`/vaner:next` in Claude Code, equivalent in
+  Cursor). Agents that don't support the skill can still use the
+  clipboard contents as a manual paste.
+- **GNOME/Wayland: no tray icon.** See [the extension note above](#gnome-on-wayland-tray-icon).
+
+## Feedback
+
+Platform-specific issues belong in the platform repo:
+
+- macOS: <https://github.com/Borgels/vaner-desktop-macos/issues>
+- Linux: <https://github.com/Borgels/vaner-desktop-linux/issues>
+
+Engine or skill issues (including `/vaner:next` behaviour) go to the
+main [Vaner repo](https://github.com/Borgels/Vaner/issues).

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -62,10 +62,14 @@ Or the plain-apt form, no pipe-to-bash:
 ```bash
 curl -fsSL https://apt.vaner.ai/release-key.asc \
   | sudo gpg --dearmor -o /etc/apt/keyrings/vaner.gpg
-echo "deb [signed-by=/etc/apt/keyrings/vaner.gpg] https://apt.vaner.ai stable main" \
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/vaner.gpg] https://apt.vaner.ai stable main" \
   | sudo tee /etc/apt/sources.list.d/vaner.list
-sudo apt update && sudo apt install vaner-desktop-linux
+sudo apt update && sudo apt install vaner
 ```
+
+The `arch=amd64` keeps apt from asking the repo for i386 indexes
+(the repo is amd64-only). The apt package is `vaner` — the repo
+slug `vaner-desktop-linux` is the GitHub identity, not the apt name.
 
 **One-off `.deb`** (no apt registration):
 

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -46,10 +46,37 @@ open vaner.xcodeproj
 
 ### Linux (Ubuntu / Debian)
 
+Signed `.deb`. The one-liner below downloads the latest release,
+verifies its detached signature against Vaner's release pubkey
+(whose fingerprint is pinned in the install script itself), and
+installs via `apt`. If the uploaded pubkey's fingerprint ever gets
+swapped, the script aborts with a mismatch error rather than trust
+an unknown signer.
+
 ```bash
-# Grab the latest .deb from the Linux releases page
-curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/latest/download/vaner_latest_amd64.deb
-sudo apt install ./vaner_latest_amd64.deb
+curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/scripts/install.sh | bash
+```
+
+Prefer to read the script before piping it? Fair.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/scripts/install.sh \
+  -o vaner-install.sh
+less vaner-install.sh   # cross-check the VANER_RELEASE_FPR pin
+bash vaner-install.sh
+```
+
+Manual verify-then-install (gpg only, no script):
+
+```bash
+VER=$(curl -fsSL https://api.github.com/repos/Borgels/vaner-desktop-linux/releases/latest | jq -r .tag_name)
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner_${VER#v}_amd64.deb
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/vaner_${VER#v}_amd64.deb.asc
+curl -LO https://github.com/Borgels/vaner-desktop-linux/releases/download/$VER/release-key.asc
+
+gpg --import release-key.asc
+gpg --verify vaner_${VER#v}_amd64.deb.asc vaner_${VER#v}_amd64.deb
+sudo apt install ./vaner_${VER#v}_amd64.deb
 ```
 
 Then launch from your app menu, or:

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -64,12 +64,15 @@ curl -fsSL https://apt.vaner.ai/release-key.asc \
   | sudo gpg --dearmor -o /etc/apt/keyrings/vaner.gpg
 echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/vaner.gpg] https://apt.vaner.ai stable main" \
   | sudo tee /etc/apt/sources.list.d/vaner.list
-sudo apt update && sudo apt install vaner
+sudo apt update && sudo apt install vaner-desktop
 ```
 
 The `arch=amd64` keeps apt from asking the repo for i386 indexes
-(the repo is amd64-only). The apt package is `vaner` — the repo
-slug `vaner-desktop-linux` is the GitHub identity, not the apt name.
+(the repo is amd64-only). The apt package is `vaner-desktop` — the
+bare `vaner` name is reserved for the daemon CLI (the Python engine),
+so future apt distribution of the engine doesn't collide. The repo
+slug `vaner-desktop-linux` is the GitHub identity, separate from
+both.
 
 **One-off `.deb`** (no apt registration):
 

--- a/content/docs/desktop.mdx
+++ b/content/docs/desktop.mdx
@@ -60,9 +60,9 @@ curl -fsSL https://raw.githubusercontent.com/Borgels/vaner-desktop-linux/main/sc
 Or the plain-apt form, no pipe-to-bash:
 
 ```bash
-curl -fsSL https://borgels.github.io/vaner-desktop-linux/release-key.asc \
+curl -fsSL https://apt.vaner.ai/release-key.asc \
   | sudo gpg --dearmor -o /etc/apt/keyrings/vaner.gpg
-echo "deb [signed-by=/etc/apt/keyrings/vaner.gpg] https://borgels.github.io/vaner-desktop-linux stable main" \
+echo "deb [signed-by=/etc/apt/keyrings/vaner.gpg] https://apt.vaner.ai stable main" \
   | sudo tee /etc/apt/sources.list.d/vaner.list
 sudo apt update && sudo apt install vaner-desktop-linux
 ```

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -11,6 +11,11 @@ This section covers integration modes and tool-specific recipes.
 - [MCP mode](/integrations/mcp): native IDE/agent integration where models pull prepared scenarios via tools.
 - [Tool-specific pages](/integrations/tools/cursor-mcp): copy/paste setup and verification by client.
 
+## Integration layer (0.8.5)
+
+- [Integration layer](/integrations/integration-layer): guidance assets, capability tiers, context injection, adopted-package handoff. Makes Vaner useful even when the backend LLM doesn't proactively call MCP tools.
+- [MCP Apps UI](/integrations/mcp-apps-ui): interactive active-predictions dashboard served as an `ui://` resource to MCP Apps capable clients (Claude Desktop, ChatGPT); structured text fallback for everyone else.
+
 ## Advanced and compatibility modes
 
 - [Context-only mode](/integrations/context-only): call `/v1/context` directly from custom frameworks.

--- a/content/docs/integrations/integration-layer.mdx
+++ b/content/docs/integrations/integration-layer.mdx
@@ -1,0 +1,186 @@
+---
+title: Integration Layer
+description: Guidance assets, capability tiers, context injection, and the adopted-package handoff that make Vaner useful even when the backend LLM doesn't call MCP tools.
+---
+
+Vaner is a predictive preparation layer. MCP tools are one delivery path
+— but they're not the only one. 0.8.5 introduced a first-class
+integration layer so prepared work reaches agents through multiple
+surfaces, with per-client defaults driven by capability detection.
+
+The integration layer has four components:
+
+1. **Guidance asset** — a canonical, versioned markdown block agents
+   embed in their system/developer prompt so they know when to call
+   Vaner tools.
+2. **Capability tiers** — Vaner classifies the connected client into one
+   of four tiers during MCP `initialize` and picks defaults (injection
+   mode, UI resource attachment) accordingly.
+3. **Context injection** — on tiers that can accept assembled prompt
+   context, Vaner can deposit a `<VANER_PREPARED_WORK_DIGEST>` or
+   `<VANER_ADOPTED_PACKAGE>` block without the model needing to call a
+   tool.
+4. **Adopted-package handoff** — when the user clicks Adopt on a
+   desktop client, the daemon short-circuits the next `vaner.resolve`
+   call and returns the adopted Resolution verbatim.
+
+## Guidance asset
+
+The canonical guidance asset ships three variants:
+
+| Variant | Audience | Size |
+| --- | --- | --- |
+| `canonical` | Tier‑2 clients (most MCP agents — default) | ~600 tokens |
+| `weak` | Tier‑1 clients that can only accept a one-liner | ~100 tokens |
+| `strong` | Tier‑3 clients that see `<VANER_ADOPTED_PACKAGE>` markers | ~900 tokens |
+
+Each variant is exposed through three surfaces:
+
+```bash
+# CLI
+vaner guidance print --variant canonical              # body only
+vaner guidance print --variant weak --format json     # structured
+vaner guidance versions                               # list variants
+
+# HTTP
+curl localhost:8473/integrations/guidance?variant=canonical
+curl localhost:8473/integrations/guidance?variant=weak&format=markdown
+
+# MCP resource
+# In any MCP client: read the resource at vaner://guidance/current
+```
+
+The guidance asset auto-syncs into `AGENTS.md` via
+`scripts/sync_agents_primer.py` (enforced in CI). If you're writing
+agent instructions in your own repo, you can embed the same block
+verbatim — it's versioned via the `vaner-primer:start v=…` marker.
+
+## Capability tiers
+
+| Tier | What the client can do | Default behavior |
+| --- | --- | --- |
+| **Tier 1** | MCP tools only | No injection. Guidance available by request. |
+| **Tier 2** | + Prompt guidance | Canonical guidance embedded. Digest-only injection. |
+| **Tier 3** | + Context mediation | Adopted-package + digest injection. Freshness checks. |
+| **Tier 4** | + MCP Apps UI | Interactive `ui://vaner/active-predictions` bundle rendered. |
+
+Detection happens on first tool/resource call per session. The classifier
+reads `capabilities.experimental["io.modelcontextprotocol/ui"]` for
+Tier 4, `experimental["vaner.context_injection"]` for Tier 3,
+`roots`/`sampling` for Tier 2, else Tier 1.
+
+Run the doctor to see the active tier + config:
+
+```bash
+vaner integrations doctor
+vaner integrations doctor --format json
+```
+
+The doctor output covers: guidance version + source path, AGENTS.md
+primer parity with the canonical asset, `IntegrationsConfig` snapshot,
+daemon reachability with the `/integrations/guidance` endpoint, and any
+pending adopted-package handoff.
+
+## Context injection
+
+When mediating context on the agent's behalf, the integration layer
+emits structural blocks agents can recognize and use without calling a
+tool.
+
+### Digest block
+
+Emitted when relevant predictions exist but none are ready, or when the
+user might benefit from seeing options:
+
+```
+<VANER_PREPARED_WORK_DIGEST version="1">
+Top prepared predictions:
+1. [Ready] "Draft the project update" — Ready now
+2. [Drafting] "Compare the two research notes" — ~10–20s
+3. [Gathering evidence] "Prepare next planning step" — Working
+
+If relevant, use vaner.predictions.active or vaner.predictions.adopt to inspect or adopt one.
+</VANER_PREPARED_WORK_DIGEST>
+```
+
+### Adopted-package block
+
+Emitted when the user has clicked Adopt and the full Resolution is
+available:
+
+```
+<VANER_ADOPTED_PACKAGE version="1" expires_at="2026-04-25T12:10:00+00:00">
+Intent:
+Draft the project update
+
+Prepared briefing:
+…
+
+Predicted response:
+…
+
+Evidence:
+- doc/handoff.md (latest)
+- thread://slack/…
+
+Provenance:
+mode=predictive_hit cache=warm freshness=fresh
+Adopted from prediction: pred-abc
+</VANER_ADOPTED_PACKAGE>
+```
+
+When this block is present in the prompt, the agent should answer from
+it directly rather than re-calling `vaner.resolve` or
+`vaner.predictions.active` for the same intent.
+
+### Configuration
+
+Injection is governed by `VanerConfig.integrations.context_injection`:
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `mode` | `policy_hybrid` | One of `none` / `digest_only` / `adopted_package_only` / `top_match_auto_include` / `policy_hybrid` / `client_controlled`. |
+| `digest_token_budget` | `500` | Hard cap on digest tokens. |
+| `adopted_package_token_budget` | `2000` | Hard cap on adopted-package tokens (briefing gets 60%, response 25%, structure 15% when over budget). |
+| `max_context_fraction` | `0.20` | Never consume more than this fraction of the remaining context window. |
+| `ttl_seconds` | `600` | How long an adopted-package block is considered fresh. |
+| `include_provenance` | `true` | Include the provenance footer in the adopted-package block. |
+| `include_confidence_details` | `false` | Include raw confidence/evidence scores in the digest. |
+
+## Adopted-package handoff
+
+When the user clicks Adopt on the macOS or Linux desktop app, the client
+stashes the full `Resolution` JSON at a platform-canonical path:
+
+| OS | Path |
+| --- | --- |
+| Linux | `$XDG_STATE_HOME/vaner/pending-adopt.json` |
+| macOS | `~/Library/Application Support/Vaner/pending-adopt.json` |
+| Windows | `%LOCALAPPDATA%\Vaner\pending-adopt.json` |
+
+The daemon's `vaner.resolve` handler checks this path on every call. If
+a fresh drop exists (default TTL: 10 minutes), the handler returns it
+verbatim with `provenance.mode = "handoff_hit"` and increments the
+`tool_call_redundancy_suppressed` metric. The file is deleted on read so
+one adopted package suppresses exactly one resolve.
+
+## Metrics
+
+The following counters are available via the daemon's metrics store:
+
+- `mcp_dashboard_called`, `mcp_apps_ui_attached`, `mcp_apps_adopt_clicked`
+- `mcp_apps_bundle_read`, `guidance_resource_read_{canonical,weak,strong}`
+- `mcp_adopt_source_{mcp_app,mcp_tool,cli,desktop,unknown}`
+- `tool_call_redundancy_suppressed`
+
+## Kill-switches
+
+- `mcp.apps_ui_enabled: false` — suppress the `ui://` resource + UI bundle for the whole daemon.
+- `integrations.capability_detection_enabled: false` — skip session tier detection (falls back to `UNKNOWN` → no injection).
+- `integrations.context_injection.mode = "none"` — disable context injection without touching capability detection.
+
+## See also
+
+- [MCP Apps UI](/integrations/mcp-apps-ui) — the interactive
+  active-predictions dashboard served through `ui://vaner/active-predictions`.
+- [MCP Mode](/integrations/mcp) — the full MCP tool + resource surface.

--- a/content/docs/integrations/mcp-apps-ui.mdx
+++ b/content/docs/integrations/mcp-apps-ui.mdx
@@ -1,0 +1,134 @@
+---
+title: MCP Apps UI
+description: Vaner's interactive active-predictions dashboard for MCP Apps capable clients, with a structured text fallback for everyone else.
+---
+
+[MCP Apps](https://github.com/modelcontextprotocol/ext-apps) are an
+extension to MCP that lets servers expose interactive UI resources which
+compliant clients render inside a sandboxed iframe. Vaner ships an MCP
+Apps UI for its prediction dashboard — Tier‑4 clients get rich,
+adoptable prediction cards; every other tier gets a structured text
+fallback from the same `vaner.predictions.dashboard` tool.
+
+## Who sees the UI?
+
+Clients that advertise `io.modelcontextprotocol/ui` in their
+`capabilities.experimental` during MCP `initialize` are classified as
+Tier 4 by Vaner. The current set includes:
+
+- Claude Desktop (reference MCP Apps host)
+- ChatGPT
+- Any client that ships the `@modelcontextprotocol/ext-apps` host adapter
+
+Everyone else — Claude Code, Cursor, VS Code Copilot, Cline, Zed,
+Continue, Roo, Codex CLI, plain stdio clients — gets the structured
+text fallback on `vaner.predictions.dashboard`:
+
+```text
+Vaner has 3 active prediction(s):
+
+1. Ready — "Draft the project update"
+2. Drafting (~10–20s) — "Compare the two research notes"
+3. Gathering evidence — "Prepare next planning step"
+
+Use vaner.predictions.adopt with a prediction id to adopt one.
+```
+
+## What the UI does
+
+The `ui://vaner/active-predictions` bundle is a single-file HTML app
+that:
+
+- Loads prediction cards from the initial tool result payload.
+- Polls `vaner.predictions.active` every 5s through the host bridge to
+  refresh readiness, ETA, and adoptability.
+- Sorts adoptable-first, shows 3–5 cards by default, renders the
+  readiness label + ETA bucket + source label on every row.
+- Exposes an Adopt button per card. Adopt calls
+  `vaner.predictions.adopt` with `source: "mcp_app"`, waits for the
+  `Resolution`, shows a checkmark, and refreshes.
+- Supports light and dark color schemes, is keyboard-navigable, and
+  emits aria-live updates so screen readers announce adopt completions
+  and refresh errors.
+
+No direct calls to the local Vaner daemon. All state-changing actions
+flow through MCP tools; the host mediates postMessage both directions.
+
+## Architecture
+
+```text
+Vaner daemon
+  │
+  ├── MCP resource: ui://vaner/active-predictions  (served on read_resource)
+  │       ↑                        │
+  │       │ host iframe fetches    │
+  │       │                        ▼
+  │   ┌──────────────────────────────┐
+  │   │ Sandboxed iframe (ext-apps)  │
+  │   │  - renders cards             │
+  │   │  - polls predictions.active  │
+  │   │  - Adopt → predictions.adopt │
+  │   └──────────────────────────────┘
+  │       │ postMessage via App bridge
+  │       ▼
+  │   MCP host (Claude Desktop / ChatGPT / …)
+  │       │
+  └────── MCP tool calls ←──────────┘
+```
+
+## Security model
+
+- **Sandboxed iframe**. The host renders the bundle in a dedicated
+  iframe; no access to the parent window.
+- **Strict CSP**. The resource's `_meta.ui.csp.resourceDomains` allowlist
+  is tight — only `https://unpkg.com` for the pinned ext-apps SDK.
+  Every other domain (including the local daemon) is blocked by the
+  host-applied CSP.
+- **No direct daemon calls from the iframe**. All state-changing actions
+  go through MCP tool calls via the host bridge.
+- **No secrets in the payload**. `prepared_briefing` text is not included
+  in the dashboard initial payload — the Adopt round-trip fetches the
+  full `Resolution` only when the user explicitly clicks.
+- **Manual adopt only**. No auto-execution; every Adopt is an explicit
+  user click.
+- **HTML escape** on every user-controlled card field before DOM
+  insertion — card label, ui_summary, and source label are escaped to
+  prevent XSS even if an upstream source is malformed.
+
+## Accessibility
+
+- Keyboard navigable (tab order follows card order; no `tabindex` traps).
+- `aria-live="polite"` status region announces Adopt success, refresh
+  errors, and empty-state messaging.
+- `aria-label` on every Adopt button naming the prediction.
+- Real `<h1>` + `<ol>` + `<li>` structure (not div soup) for
+  rotor-based screen-reader navigation.
+- Light + dark color schemes via `prefers-color-scheme`.
+- Disabled Adopt buttons signal their state textually (replacing the
+  label), not just with color.
+
+## Configuration
+
+Kill-switch: `mcp.apps_ui_enabled` (default `true`). When false, the
+daemon removes `ui://vaner/active-predictions` from `list_resources` and
+the dashboard tool returns text fallback for every tier.
+
+## Dev / debugging
+
+```bash
+# Inspect the bundled HTML + its SHA-256 hash.
+vaner integrations doctor --format json  # shows mcp_apps_ui_attached metric
+
+# List resources exposed.
+# In any MCP client: call list_resources; both vaner://guidance/current
+# and ui://vaner/active-predictions should appear (the UI bundle only
+# when mcp.apps_ui_enabled=true).
+```
+
+## See also
+
+- [Integration Layer](/integrations/integration-layer) — guidance,
+  tiers, context injection, handoff.
+- [MCP Mode](/integrations/mcp) — the full tool + resource surface.
+- [MCP Apps spec](https://github.com/modelcontextprotocol/ext-apps) —
+  upstream protocol + host adapter.

--- a/content/docs/integrations/mcp.mdx
+++ b/content/docs/integrations/mcp.mdx
@@ -1,12 +1,13 @@
 ---
 title: MCP Mode
-description: Conceptual overview of Vaner's MCP integration — what tools it exposes and how clients connect.
+description: Vaner's MCP server — tools, resources, capability tiers, and MCP Apps UI.
 ---
 
 Vaner ships an [MCP](https://modelcontextprotocol.io/) server so any
 MCP-aware IDE or agent (Claude Code, Cursor, VS Code Copilot, Codex CLI,
-Windsurf, Zed, Continue, Cline, Roo, Claude Desktop, …) can pull
-scenario-ranked context without Vaner being in the model path.
+Windsurf, Zed, Continue, Cline, Roo, Claude Desktop, ChatGPT, …) can pull
+scenario-ranked context — and, on capable hosts, render an interactive
+active-predictions UI — without Vaner being in the model path.
 
 ## Start the server
 
@@ -14,22 +15,66 @@ scenario-ranked context without Vaner being in the model path.
 vaner mcp --path .
 ```
 
-The server speaks stdio by default. Clients invoke `vaner mcp --path .` as a
-subprocess and communicate over their own stdin/stdout.
+The server speaks stdio by default. Clients invoke `vaner mcp --path .` as
+a subprocess and communicate over their own stdin/stdout.
 
 ## Tools exposed
 
+The MCP tool surface is organized around prediction lifecycle + workspace
+state. Start with the prediction tools and fall back to `vaner.resolve`
+only when nothing prepared matches.
+
+### Predictions
+
 | Tool | Purpose |
 | --- | --- |
-| `list_scenarios` | Scenarios Vaner has precomputed for this repo. |
-| `get_scenario` | Retrieve full context, evidence, and coverage gaps for one scenario. |
-| `expand_scenario` | Trigger deeper precompute and return the refreshed scenario. |
-| `compare_scenarios` | Compare overlap/divergence between scenario candidates. |
-| `report_outcome` | Send usefulness feedback (`useful`, `partial`, `irrelevant`) for learning. |
+| `vaner.predictions.active` | List predictions Vaner has prepared, ranked by readiness. Includes `readiness_label`, `eta_bucket`, `adoptable`, `rank`. |
+| `vaner.predictions.dashboard` | Open the interactive predictions dashboard (MCP Apps UI on Tier‑4 clients; structured text fallback on everyone else). |
+| `vaner.predictions.adopt` | Adopt a specific prediction — returns the prepared `Resolution`. `source` arg distinguishes `mcp_app` / `mcp_tool` / `cli` / `desktop`. |
 
-All tools are scoped to the `--path` Vaner was started with.
+### Context resolution
 
-Each tool also accepts an optional `skill` argument for attribution. This lets Vaner track which agent skill drove calls/outcomes and route feedback into frontier adaptation.
+| Tool | Purpose |
+| --- | --- |
+| `vaner.resolve` | Build a context package for an explicit query when no prediction matches. Returns briefing + draft + ranked evidence + provenance. |
+| `vaner.search` | Fallback retrieval (semantic / lexical / hybrid / symbol / path) when predictive confidence is weak. |
+| `vaner.expand` | Expand a scenario/evidence branch without recomputing everything. |
+| `vaner.suggest` | Lightweight intent suggestions before full resolution. |
+| `vaner.explain` | Explain why a package was selected and where uncertainty remains. |
+| `vaner.inspect` | Read a normalized scenario/evidence item by id. |
+
+### Workspace state
+
+| Tool | Purpose |
+| --- | --- |
+| `vaner.goals.*` | Declare, list, update, and delete long-horizon workspace goals that bias prediction ranking. |
+| `vaner.artefacts.*` | Inspect intent-bearing artefacts (plans, outlines, issues) + their downstream influence. |
+| `vaner.sources.status` | Per-source ingestion pipeline status. |
+| `vaner.deep_run.*` | Overnight Deep-Run session lifecycle (start / stop / status / list / show). |
+| `vaner.status` | Vaner readiness, freshness, and memory health. |
+
+### Learning + debug
+
+| Tool | Purpose |
+| --- | --- |
+| `vaner.feedback` | Record usefulness (`useful` / `partial` / `wrong` / `irrelevant`) with optional correction. |
+| `vaner.warm` | Hint Vaner to precompute around selected targets. |
+| `vaner.debug.trace` | Debug trace of the most recent decision + memory state. |
+
+## Resources exposed
+
+MCP clients that fetch resources get two:
+
+- `vaner://guidance/current` — the canonical operational guidance asset. Agents should embed this in the system/developer prompt. See [Integration Layer](/integrations/integration-layer).
+- `ui://vaner/active-predictions` — the MCP Apps UI bundle for the active-predictions dashboard (served on Tier‑4 clients; see [MCP Apps UI](/integrations/mcp-apps-ui)).
+
+## Capability tiers
+
+Vaner classifies the connected client into one of four tiers during MCP
+`initialize` and picks sensible defaults accordingly. See [Integration
+Layer](/integrations/integration-layer) for the tier contract, the
+detection rules, and how `vaner integrations doctor` reports the active
+tier.
 
 ## Want to wire it up?
 
@@ -39,10 +84,7 @@ Each tool also accepts an optional `skill` argument for attribution. This lets V
 
 ## When to use MCP vs other modes
 
-- **MCP mode** (this page): your IDE already orchestrates model calls and only
-  needs Vaner-provided context. Lowest coupling; recommended default.
-- **[Proxy mode](/integrations/proxy)**: tools that only speak the OpenAI
-  `/v1/chat/completions` shape.
-- **[Context-only mode](/integrations/context-only)**: frameworks that call
-  `/v1/context` directly.
+- **MCP mode** (this page): your IDE or agent already orchestrates model calls and only needs Vaner-provided context. Lowest coupling; recommended default.
+- **[Proxy mode](/integrations/proxy)**: tools that only speak the OpenAI `/v1/chat/completions` shape.
+- **[Context-only mode](/integrations/context-only)**: frameworks that call `/v1/context` directly.
 - **[Python SDK](/integrations/python-sdk)**: custom scripts.

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -3,6 +3,8 @@
   "pages": [
     "index",
     "mcp",
+    "integration-layer",
+    "mcp-apps-ui",
     "tools",
     "context-only",
     "python-sdk",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -4,6 +4,7 @@
     "index",
     "getting-started",
     "usage",
+    "desktop",
     "ai-prompts",
     "troubleshooting",
     "mcp",


### PR DESCRIPTION
Documents the 0.8.5 integration layer landing in https://github.com/Borgels/vaner/pull/157..165. Three updated/new pages: mcp.mdx rewrite, integration-layer.mdx (new), mcp-apps-ui.mdx (new). 🤖 Generated with Claude Code