### PR TITLE
docs(integrations): 0.8.5 WS12-B — quickstart + clients-cli + per-client refresh

### DIFF
--- a/content/docs/integrations/clients-cli.mdx
+++ b/content/docs/integrations/clients-cli.mdx
@@ -1,0 +1,156 @@
+---
+title: Clients CLI
+description: vaner clients — install, uninstall, status, and drift-recovery for every supported MCP client.
+---
+
+`vaner clients` is the headless equivalent of the desktop app's MCP Clients pane. Use it from CI, SSH sessions, or anywhere a GUI isn't an option. It's idempotent, backup-safe, and never drops user-configured non-Vaner MCP servers.
+
+## Subcommand reference
+
+| Command | What it does |
+| --- | --- |
+| `vaner clients detect` | List MCP clients detected on this machine + their config status. |
+| `vaner clients install <name>` | Install Vaner into a single client. |
+| `vaner clients install --all` | Install Vaner into every detected client. |
+| `vaner clients uninstall <name>` | Remove the Vaner entry from a single client. |
+| `vaner clients uninstall --all` | Remove Vaner from every configured client. |
+| `vaner clients status` | Pretty matrix of install/configured state. |
+| `vaner clients doctor` | Detect launcher path drift after Vaner is reinstalled / moved. |
+
+Every command supports `--format pretty` (default) and `--format json`. JSON output is a stable contract for tooling.
+
+## Examples
+
+### What's on this machine?
+
+```bash
+$ vaner clients detect
+                MCP clients
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Client           ┃ Status       ┃ Path                       ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ Cursor           │ ✓ Configured │ ~/.cursor/mcp.json         │
+│ Claude Desktop   │ · Detected   │ ~/.config/Claude/...       │
+│ Claude Code      │ · Detected   │ -                          │
+│ Cline            │ ✗ Missing    │ -                          │
+│ Continue         │ · Detected   │ ~/.continue/mcpServers/... │
+│ ...                                                          │
+└──────────────────┴──────────────┴────────────────────────────┘
+```
+
+JSON output (use this from scripts):
+
+```bash
+$ vaner clients detect --format json
+{
+  "clients": [
+    {
+      "id": "cursor",
+      "label": "Cursor",
+      "kind": "json-mcpServers",
+      "status": "configured",
+      "detected": true,
+      "configured": true,
+      "config_path": "/home/me/.cursor/mcp.json",
+      "detail": "already configured"
+    },
+    ...
+  ]
+}
+```
+
+### One-shot install for everything detected
+
+```bash
+$ vaner clients install --all
+✓ cursor: updated at /home/me/.cursor/mcp.json
+✓ claude-desktop: added at /home/me/.config/Claude/claude_desktop_config.json
+✓ continue: added at /home/me/.continue/mcpServers/vaner.yaml
+· claude-code: skipped (claude binary not found)
+```
+
+Skipping is normal for clients whose binary or config dir is absent — Vaner won't write speculative configs.
+
+### Single client, dry-run preview
+
+```bash
+$ vaner clients install claude-desktop --dry-run --format json
+{
+  "results": [
+    {
+      "client_id": "claude-desktop",
+      "path": "/home/me/.config/Claude/claude_desktop_config.json",
+      "action": "skipped",
+      "error": "dry-run",
+      ...
+    }
+  ]
+}
+```
+
+`--dry-run` exits without touching any file. Use it before automation.
+
+### Detect launcher drift (after reinstall / upgrade)
+
+When Vaner moves (e.g. `pipx` → `uv tool install`, or system → user install), every client config now points at the old path:
+
+```bash
+$ vaner clients doctor
+                Launcher drift
+┏━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
+┃ Client           ┃ Configured             ┃ Expected            ┃
+┡━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
+│ Cursor           │ /old/path/vaner        │ /new/path/vaner     │
+│ Claude Desktop   │ /old/path/vaner        │ /new/path/vaner     │
+└──────────────────┴────────────────────────┴─────────────────────┘
+
+Fix: run `vaner clients install --all --force`
+```
+
+Doctor exits **non-zero** when drift is found — wire it into your CI / shell-rc to catch silent breakage.
+
+## Per-client config locations
+
+| Client | Path | Format |
+| --- | --- | --- |
+| Cursor | `~/.cursor/mcp.json` | `mcpServers` JSON |
+| Claude Desktop (macOS) | `~/Library/Application Support/Claude/claude_desktop_config.json` | `mcpServers` JSON |
+| Claude Desktop (Linux) | `~/.config/Claude/claude_desktop_config.json` | `mcpServers` JSON |
+| Claude Code | (CLI-managed via `claude mcp add`) | n/a |
+| VS Code (Copilot) | `~/.config/Code/User/mcp.json` | `servers` JSON |
+| Codex CLI | (CLI-managed via `codex mcp add`) | n/a |
+| Windsurf | `~/.codeium/windsurf/mcp_config.json` | `mcpServers` JSON |
+| Zed | `~/.config/zed/settings.json` | `context_servers` JSON |
+| Continue | `~/.continue/mcpServers/vaner.yaml` | per-server YAML |
+| Cline | `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json` | `mcpServers` JSON |
+| Roo Code | `~/.roo/mcp_settings.json` | `mcpServers` JSON |
+
+## How install merges with existing entries
+
+For JSON-shaped configs, install writes only the `vaner` (or `vaner-<reponame>` for Claude Desktop) entry inside the `mcpServers` / `servers` / `context_servers` container. Every other entry the user already has is preserved verbatim. Before any write the existing file is hashed; if the new content is byte-identical, the write is skipped (`action: skipped`). Otherwise the existing file is rotated to a backup (last 3 kept) and the new content is atomically replaced.
+
+For YAML (Continue), install writes a single Vaner-only document to `~/.continue/mcpServers/vaner.yaml`. Other Continue MCP servers live in their own files; we don't touch them.
+
+For CLI-managed clients (Claude Code, Codex CLI), install shells out to the client's own `mcp add` command with `--scope user`.
+
+## Idempotency + safety
+
+- Re-running `vaner clients install --all` on a configured machine is a no-op (every result is `skipped`).
+- `--force` rewrites even matching entries; useful after launcher drift.
+- `--dry-run` previews without writing anywhere.
+- Backups land alongside the original file as `<name>.vaner-backup-<timestamp>`. Last 3 kept; older rotated automatically.
+- Atomic writes via `tempfile.mkstemp() + os.replace()` — no half-written configs even on crash.
+
+## Programmatic use
+
+The `--format json` shape is the contract the desktop apps consume. The `WriteResult.action` field is `"added" | "updated" | "skipped" | "failed"`; the `error` field carries the human-readable reason for skip/fail.
+
+```bash
+$ vaner clients install --all --format json | jq '.results[] | select(.action == "failed")'
+```
+
+## See also
+
+- [Quickstart](/integrations/quickstart) — the desktop-app path that wraps this CLI.
+- [Integration Layer](/integrations/integration-layer) — capability tiers and the broader integration story.
+- [MCP Mode](/integrations/mcp) — full Vaner MCP tool surface.

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -8,13 +8,15 @@ This section covers integration modes and tool-specific recipes.
 
 ## Default integration (recommended)
 
+- [Quickstart](/integrations/quickstart): zero → wired-everywhere in two clicks via the desktop app, or one CLI command headless.
 - [MCP mode](/integrations/mcp): native IDE/agent integration where models pull prepared scenarios via tools.
 - [Tool-specific pages](/integrations/tools/cursor-mcp): copy/paste setup and verification by client.
 
 ## Integration layer (0.8.5)
 
 - [Integration layer](/integrations/integration-layer): guidance assets, capability tiers, context injection, adopted-package handoff. Makes Vaner useful even when the backend LLM doesn't proactively call MCP tools.
-- [MCP Apps UI](/integrations/mcp-apps-ui): interactive active-predictions dashboard served as an `ui://` resource to MCP Apps capable clients (Claude Desktop, ChatGPT); structured text fallback for everyone else.
+- [MCP Apps UI](/integrations/mcp-apps-ui): interactive active-predictions dashboard served as an `ui://` resource to MCP Apps capable clients (Claude Desktop, Cursor 2.6+, ChatGPT); structured text fallback for everyone else.
+- [Clients CLI](/integrations/clients-cli): `vaner clients` reference — install, uninstall, status, drift recovery for all 10 supported MCP clients.
 
 ## Advanced and compatibility modes
 

--- a/content/docs/integrations/mcp-apps-ui.mdx
+++ b/content/docs/integrations/mcp-apps-ui.mdx
@@ -17,12 +17,18 @@ Clients that advertise `io.modelcontextprotocol/ui` in their
 Tier 4 by Vaner. The current set includes:
 
 - Claude Desktop (reference MCP Apps host)
+- **Cursor 2.6+** (added April 2026)
 - ChatGPT
 - Any client that ships the `@modelcontextprotocol/ext-apps` host adapter
 
-Everyone else — Claude Code, Cursor, VS Code Copilot, Cline, Zed,
-Continue, Roo, Codex CLI, plain stdio clients — gets the structured
-text fallback on `vaner.predictions.dashboard`:
+Vaner's tier classification is value-driven — it matches on the
+`io.modelcontextprotocol/ui` capability key, not the client name. New
+hosts that adopt MCP Apps automatically promote to Tier 4 the moment
+they advertise the extension; no Vaner-side change required.
+
+Everyone else — Claude Code, Cursor pre-2.6, VS Code Copilot, Cline,
+Zed, Continue, Roo, Codex CLI, plain stdio clients — gets the
+structured text fallback on `vaner.predictions.dashboard`:
 
 ```text
 Vaner has 3 active prediction(s):

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -2,9 +2,11 @@
   "title": "Integrations",
   "pages": [
     "index",
+    "quickstart",
     "mcp",
     "integration-layer",
     "mcp-apps-ui",
+    "clients-cli",
     "tools",
     "context-only",
     "python-sdk",

--- a/content/docs/integrations/quickstart.mdx
+++ b/content/docs/integrations/quickstart.mdx
@@ -1,0 +1,88 @@
+---
+title: Quickstart
+description: From zero to Vaner-wired in every MCP client on your machine, in two clicks.
+---
+
+This is the shortest path from "Vaner is installed" to "every MCP client I have on this machine sees Vaner". For the why-and-how, see [Integration Layer](/integrations/integration-layer) and [MCP Apps UI](/integrations/mcp-apps-ui).
+
+## 1. Install Vaner
+
+```bash
+curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
+```
+
+Or via uv:
+
+```bash
+uv tool install vaner
+```
+
+## 2. Open the desktop app
+
+The macOS and Linux desktop apps ship the same first-run flow:
+
+1. **Launch** Vaner Desktop (download from [vaner.ai/download](https://vaner.ai/download)).
+2. **Pick the repo** you want Vaner to watch (or accept the default).
+3. **Install for detected MCP clients** — the onboarding shows a checklist of every MCP client found on this machine (Cursor, Claude Desktop, Claude Code, Cline, Continue, Zed, Windsurf, VS Code, Codex CLI, Roo). Every detected client is checked by default. Click **Install for selected**.
+
+That's it. Every checked client now has a Vaner entry in its MCP config and will see Vaner on next restart.
+
+> **Already past first-run?** Open Preferences → MCP Clients to install for additional clients later, see status, or recover from launcher drift.
+
+## 3. Try it from any agent
+
+In any MCP-connected agent (Cursor, Claude Desktop, Claude Code, etc.) ask:
+
+> "Show me the Vaner dashboard."
+
+The agent calls `vaner.predictions.dashboard`. On Tier-4 hosts (Claude Desktop, Cursor 2.6+, ChatGPT) you'll see an inline iframe with prediction cards + Adopt buttons. On Tier-1/2 hosts you'll see structured text with the same information. Either way, Adopt works.
+
+## How it all fits together
+
+```text
+┌─────────────────────────┐    starts/configures      ┌─────────────────────┐
+│ Vaner Desktop (macOS    │ ────────────────────────► │ vaner daemon        │
+│ or Linux)               │   `vaner clients install` │ + MCP server        │
+│                         │   for every detected host │ (loopback :8473)    │
+└────────────┬────────────┘                           └──────────┬──────────┘
+             │ shows native prediction cards                     │
+             │ (consumes /predictions/active)                    │
+             │                                                   │
+             │ user clicks Adopt                                 │
+             ▼                                                   │
+   ┌─────────────────────┐  drops pending-adopt.json              │
+   │ Resolution stashed  │ ───────────────────────────────────────┤
+   └─────────────────────┘                                        │
+                                                                  │
+   ┌─────────────────────┐                                        │
+   │ Cursor / Claude /   │   MCP tool calls                       │
+   │ any MCP client      │ ◄──────────────────────────────────────┘
+   └─────────────────────┘   vaner.resolve sees fresh handoff,
+                             returns the adopted package verbatim
+```
+
+The desktop app is the **visual cockpit** + **Adopt button** + **install helper**. The agent integration (Cursor / Claude Desktop / etc.) consumes the same daemon over MCP. The MCP Apps UI bundle is for chat hosts that don't have a desktop cockpit running — it's the same dashboard, rendered server-side.
+
+## Headless / CI / SSH workflows
+
+If you don't have a GUI, the desktop app's install logic is also a CLI. See [Clients CLI](/integrations/clients-cli) for the full reference. Quick path:
+
+```bash
+vaner clients detect                  # what's on this machine
+vaner clients install --all           # wire everything detected
+vaner clients install claude-desktop  # one client only
+vaner clients doctor                  # detect launcher drift after upgrades
+```
+
+## Troubleshooting
+
+- **My MCP client isn't detected.** Make sure it's installed (try launching it once) and click **Refresh** in Preferences → MCP Clients. The detection logic is in [`mcp_clients.py`](https://github.com/Borgels/Vaner/blob/main/src/vaner/cli/commands/mcp_clients.py); requesting support for a new client takes a one-entry registry change.
+- **I upgraded Vaner and now my agents say "vaner: command not found".** The `vaner` binary moved (e.g. `uv` → `pipx`). Run `vaner clients doctor` or open Preferences → MCP Clients — the drift banner will offer one-click "Update All". Headless: `vaner clients install --all --force`.
+- **I want Vaner OUT of a specific client.** `vaner clients uninstall <name>` from CLI, or open Preferences → MCP Clients → Remove. Symmetric with install; backups preserved.
+
+## See also
+
+- [Integration Layer](/integrations/integration-layer) — guidance assets, capability tiers, context injection, adopted-package handoff.
+- [MCP Apps UI](/integrations/mcp-apps-ui) — interactive prediction-card dashboard, security model, fallback behavior.
+- [MCP Mode](/integrations/mcp) — full MCP tool + resource surface.
+- [Clients CLI](/integrations/clients-cli) — `vaner clients` command reference.

--- a/content/docs/integrations/tools/claude-code-mcp.mdx
+++ b/content/docs/integrations/tools/claude-code-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install claude-code` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install claude-code` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -34,7 +39,7 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Scope `/tmp` work to your repo: Claude Code hits Vaner for `list_scenarios` before running its own tools.
+- Scope `/tmp` work to your repo: Claude Code hits Vaner for `vaner.predictions.active` before running its own tools.
 - Switch between `user` / `project` / `local` scope without editing JSON by hand.
 - Tight loop with `claude --resume` — Vaner keeps the ponder cache between sessions.
 

--- a/content/docs/integrations/tools/claude-desktop-mcp.mdx
+++ b/content/docs/integrations/tools/claude-desktop-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install claude-desktop` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install claude-desktop` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 

--- a/content/docs/integrations/tools/cline-mcp.mdx
+++ b/content/docs/integrations/tools/cline-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install cline` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install cline` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -26,7 +31,7 @@ vaner init --path .
 
 ## Verify
 
-Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.
+Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `vaner.predictions.active` from the chat.
 
 If `Cline` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a

--- a/content/docs/integrations/tools/codex-cli-mcp.mdx
+++ b/content/docs/integrations/tools/codex-cli-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install codex-cli` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install codex-cli` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -34,7 +39,7 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Feed Vaner context to Codex CLI sessions: `codex exec "refactor X"` can call `list_scenarios` and `get_scenario` first.
+- Feed Vaner context to Codex CLI sessions: `codex exec "refactor X"` can call `vaner.predictions.active` and `vaner.predictions.active` first.
 - Pin a per-repo backend in `~/.codex/config.toml` alongside the Vaner entry.
 - Pair with `vaner daemon start` to keep ponder warm between CLI invocations.
 

--- a/content/docs/integrations/tools/continue-mcp.mdx
+++ b/content/docs/integrations/tools/continue-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install continue` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install continue` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -26,7 +31,7 @@ vaner init --path .
 
 ## Verify
 
-Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.
+Reload Continue. Ask the agent to list available MCP tools — `vaner.vaner.predictions.active` should be present.
 
 If `Continue` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,9 +39,9 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Continue’s agent mode calls `vaner.list_scenarios` between steps for grounded plans.
+- Continue’s agent mode calls `vaner.vaner.predictions.active` between steps for grounded plans.
 - Ship the YAML in `.continue/` so teammates inherit the integration.
-- Combine with Continue’s code lenses to open `vaner.get_scenario` payloads inline.
+- Combine with Continue’s code lenses to open `vaner.vaner.predictions.active` payloads inline.
 
 ## See also
 

--- a/content/docs/integrations/tools/cursor-mcp.mdx
+++ b/content/docs/integrations/tools/cursor-mcp.mdx
@@ -1,45 +1,70 @@
 ---
 title: Cursor + Vaner (MCP)
-description: Connect Cursor to Vaner over MCP for predictive, repo-grounded context.
+description: Connect Cursor to Vaner — including the new MCP Apps UI in Cursor 2.6+.
 ---
 
-[Cursor](https://docs.cursor.com/en/context/mcp) supports the
-[Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+[Cursor](https://docs.cursor.com/en/context/mcp) is an original MCP
+client and as of **2.6+** also supports the
+[MCP Apps UI extension](https://github.com/modelcontextprotocol/ext-apps),
+so Vaner's interactive prediction dashboard renders inline.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects Cursor and writes the right config automatically.
 
-## Install
-
-If you haven't installed Vaner yet:
+## Headless / no-GUI install
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
-vaner init --path .
+vaner clients install cursor          # global user install
+# Or — per-repo:
+vaner clients install cursor --repo-root . --scope repo
 ```
 
-## Connect Cursor
+See [Clients CLI](/integrations/clients-cli) for the full reference.
 
-<McpClientPicker initialClient="cursor" lockClient />
+## Manual config (if you prefer)
+
+Both the desktop app and `vaner clients install` write this to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "vaner": {
+      "command": "/absolute/path/to/vaner",
+      "args": ["mcp", "--path", "/absolute/path/to/your/repo"]
+    }
+  }
+}
+```
+
+If Cursor is already wired against an older Vaner install path and the binary moved (you reinstalled via uv / pipx / Homebrew), run `vaner clients doctor` to detect drift, then `vaner clients install --all --force` to repair.
 
 ## Verify
 
-Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.
+1. Restart Cursor.
+2. Open Settings → MCP. `vaner` should appear with a green status pill.
+3. From Composer, ask: *"Show me the Vaner dashboard."* Cursor calls `vaner.predictions.dashboard`.
 
-If `Cursor` reports the server as failed, run `vaner mcp --path .`
-manually in a terminal and read the error. The most common failure is a
-missing backend API key — confirm with `vaner config show`.
+### What you'll see
 
-## What this unlocks
+- **Cursor 2.6+**: an inline iframe with prediction cards + Adopt buttons. Cards refresh every 5 s; clicking Adopt converts the prediction into a Resolution and short-circuits the next `vaner.resolve` call.
+- **Cursor pre-2.6**: a structured text fallback with the same data (numbered list of predictions). Functional but not interactive.
 
-- Composer can call `list_scenarios`/`get_scenario` for "where is X?" prompts instead of grepping from scratch.
-- Project-scoped config keeps Vaner active only in the repos you want.
-- Agent mode can compare alternatives with `compare_scenarios` and close the loop with `report_outcome`.
+If Cursor reports the server as failed, run `vaner mcp --path .` manually in a terminal and read the error. The most common failure is a missing backend API key — confirm with `vaner config show`.
+
+## Tools to call
+
+- `vaner.predictions.active` — see prepared next-step predictions.
+- `vaner.predictions.dashboard` — open the interactive UI (or text fallback).
+- `vaner.predictions.adopt {prediction_id}` — pick one.
+- `vaner.resolve {query}` — full resolve when nothing prepared matches.
+- `vaner.feedback {rating, …}` — close the loop after a Vaner-assisted turn.
+
+See [MCP mode](/integrations/mcp) for the full surface.
 
 ## See also
 
-- The full [Connect your client](/mcp) guide.
-- [Backends](/backends) for picking the model Vaner ponders with.
-- Upstream docs: [https://docs.cursor.com/en/context/mcp](https://docs.cursor.com/en/context/mcp).
+- [MCP Apps UI](/integrations/mcp-apps-ui) — what the dashboard looks like + security model.
+- [Integration Layer](/integrations/integration-layer) — capability tiers, context injection, adopted-package handoff.
+- [Quickstart](/integrations/quickstart) — end-to-end install in two clicks.
+- Upstream docs: [docs.cursor.com/en/context/mcp](https://docs.cursor.com/en/context/mcp).

--- a/content/docs/integrations/tools/roo-mcp.mdx
+++ b/content/docs/integrations/tools/roo-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install roo` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install roo` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -26,7 +31,7 @@ vaner init --path .
 
 ## Verify
 
-Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.
+Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `vaner.predictions.active`.
 
 If `Roo Code` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,7 +39,7 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Roo Code’s agent mode can call `list_scenarios`/`get_scenario` before writing diffs.
+- Roo Code’s agent mode can call `vaner.predictions.active`/`vaner.predictions.active` before writing diffs.
 - Project-level `.roo/mcp.json` so repos opt in explicitly.
 - Works with Roo’s orchestration to break large changes into Vaner-informed steps.
 

--- a/content/docs/integrations/tools/vscode-copilot-mcp.mdx
+++ b/content/docs/integrations/tools/vscode-copilot-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install vscode-copilot` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install vscode-copilot` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 
@@ -26,7 +31,7 @@ vaner init --path .
 
 ## Verify
 
-Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.
+Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `vaner.predictions.active`.
 
 If `VS Code (Copilot)` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a

--- a/content/docs/integrations/tools/windsurf-mcp.mdx
+++ b/content/docs/integrations/tools/windsurf-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install windsurf` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install windsurf` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 

--- a/content/docs/integrations/tools/zed-mcp.mdx
+++ b/content/docs/integrations/tools/zed-mcp.mdx
@@ -9,7 +9,12 @@ Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
 agent before every prompt.
 
 > [!TIP]
-> Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
+> Or just run `vaner clients install zed` from your project root — it will detect and configure this client for you.
+
+> [!TIP]
+> **Easiest path:** open the Vaner desktop app and click *Install for all clients* in the first-run flow (or in Preferences → MCP Clients). Vaner detects this client and writes the right config automatically.
+>
+> Headless: `vaner clients install zed` — see [Clients CLI](/integrations/clients-cli).
 
 ## Install
 


### PR DESCRIPTION
Stacks on #22 (WS10). Adds quickstart.mdx + clients-cli.mdx; refreshes all 10 per-client tools/*.mdx pages with the desktop-app one-click + `vaner clients install` headless path; replaces legacy list_scenarios/get_scenario refs with 0.8.5 surface; adds Cursor 2.6+ to the MCP Apps Tier-4 list. `npm run build` clean. 🤖 Generated with Claude Code