### PR TITLE
docs: Windows install + simple-mode entry point

### DIFF
--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -38,6 +38,14 @@ before installing missing prerequisites (Python 3.11+, `uv`/`pipx`), and
 installs `vaner[mcp]` so the MCP server is ready out of the box. Pass
 `--no-mcp` to skip the MCP extra.
 
+On **Windows**, install via `pip` or `pipx` directly (the bash installer
+above is POSIX-only):
+
+```powershell
+pip install "vaner[mcp]"   # or: pipx install "vaner[mcp]"
+vaner init
+```
+
 ### Non-interactive install (CI, Dockerfiles)
 
 ```bash

--- a/content/docs/simple-mode.mdx
+++ b/content/docs/simple-mode.mdx
@@ -29,7 +29,7 @@ From the desktop app:
 
 - **macOS** — Vaner Companion → "Open setup wizard" in Onboarding,
   or Preferences → Engine → "Switch to Simple".
-- **Linux** — Vaner Desktop → first-run `/setup` route, or
+- **Linux / Windows** — Vaner Desktop → first-run `/setup` route, or
   Preferences → Engine → Simple tab.
 
 ## The five questions


### PR DESCRIPTION
## Summary

The Tauri desktop repo `vaner-desktop-linux` was renamed to `vaner-desktop` and now also builds a Windows NSIS installer. See [Borgels/vaner-desktop#4](https://github.com/Borgels/vaner-desktop/pull/4).

- `getting-started.mdx` — adds a Windows install snippet (`pip install \"vaner[mcp]\"`) since the bash installer is POSIX-only.
- `simple-mode.mdx` — desktop entry-point bullet is now \"Linux / Windows\" (same binary).

No layout / nav / styling changes.

## Test plan

- [ ] `pnpm dev` renders both pages without errors.
- [ ] Code blocks highlight correctly in dark + light themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)