### PR TITLE
docs: refresh Prepared Work and MCP documentation

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -28,6 +28,7 @@ jobs:
             --exclude '^https://docs\.vaner\.ai/policy-bundles($|#)'
             --exclude '^https://docs\.vaner\.ai/hardware-tiers($|#)'
             --exclude '^https://docs\.vaner\.ai/deep-run($|#)'
+            --exclude '^https://docs\.vaner\.ai/prepared-work($|#)'
             --exclude https://docs.vaner.ai/integrations/integration-layer
             "./**/*.md"
             "./**/*.mdx"

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -29,6 +29,7 @@ jobs:
             --exclude '^https://docs\.vaner\.ai/hardware-tiers($|#)'
             --exclude '^https://docs\.vaner\.ai/deep-run($|#)'
             --exclude '^https://docs\.vaner\.ai/prepared-work($|#)'
+            --exclude '^https://docs\.vaner\.ai/human-product-proof($|#)'
             --exclude https://docs.vaner.ai/integrations/integration-layer
             "./**/*.md"
             "./**/*.mdx"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,4 +5,4 @@ This repository only contains public documentation content and site code.
 For security vulnerabilities in Vaner, report privately through the main
 project policy:
 
-- https://github.com/Borgels/Vaner/security/policy
+- https://github.com/Borgels/vaner/security/policy

--- a/app/(docs)/layout.tsx
+++ b/app/(docs)/layout.tsx
@@ -17,7 +17,7 @@ export default function Layout({ children }: { children: ReactNode }) {
         },
         {
           text: 'GitHub',
-          url: 'https://github.com/Borgels/Vaner',
+          url: 'https://github.com/Borgels/vaner',
         },
       ]}
     >

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -1,21 +1,25 @@
 ---
 title: Architecture
-description: How Vaner runs beside your model and serves scenarios over MCP.
+description: How Vaner runs beside your model and serves Prepared Work over MCP and HTTP.
 ---
 
 Vaner is built around one default architecture:
 
 - **MCP-first model interface:** your client calls tools; Vaner is not the chat
   completion hot path.
-- **Side-running ponder engine:** Vaner precomputes scenarios in the background.
+- **Side-running ponder engine:** Vaner precomputes likely useful work in the
+  background.
+- **Prepared Work surface:** clients see a small, action-oriented feed instead
+  of raw prediction/work-product lifecycle state.
 - **Local cockpit controls:** operators inspect, debug, and tune behavior.
 
 ## Two loops: precompute and serve
 
-- **Ponder loop (background):** watches repo signals, expands frontier candidates,
-  and refreshes scenario context in storage.
-- **Answer loop (prompt-time):** serves precomputed scenarios over MCP tools when
-  your client asks for context during a real task.
+- **Ponder loop (background):** watches repo signals, expands frontier
+  candidates, and refreshes scenarios, artifacts, predictions, and work
+  products in storage.
+- **Answer loop (prompt-time):** serves Prepared Work or precomputed context over
+  MCP/HTTP when your client asks during a real task.
 
 This split is the core performance model: expensive exploration happens between
 prompts, while prompt-time retrieval stays fast and deterministic.
@@ -29,9 +33,10 @@ flowchart LR
   Intent --> Frontier[ExplorationFrontier]
   Frontier --> Builder[ScenarioBuilder]
   Builder --> Store[ScenarioStore]
-  Store --> MCP[MCPServer]
+  Store --> Prepared[PreparedWork]
+  Prepared --> MCP[MCPServer]
   MCP --> Agent[IDEOrAgent]
-  Agent -->|report_outcome| MCP
+  Agent -->|feedback| MCP
   MCP --> Feedback[FeedbackQueue]
   Feedback --> Frontier
   Store --> Cockpit[CockpitHTTPAndCLI]
@@ -51,6 +56,16 @@ Each scenario stores prepared context, evidence references, freshness, expansion
 cost, and outcomes. Vaner re-scores scenarios so clients can pick promising
 candidates quickly via MCP tools.
 
+### Prepared Work layer
+
+Prepared Work is the product-facing layer above predictions and work products.
+It filters hidden/stale/dismissed/superseded items, ranks by usefulness,
+confidence, freshness, evidence, and actionability, and returns UI-safe cards
+with only server-authorized actions.
+
+Virtual diffs live in Vaner-owned storage. They can be inspected and exported,
+but Vaner does not automatically mutate the user's worktree.
+
 ### Agent skills prior
 
 Vaner can discover active `SKILL.md` files and treat them as intent priors.
@@ -61,10 +76,9 @@ See [Agent Skills](/skills) for the full loop.
 
 ### MCP runtime (model pull)
 
-MCP tools (`list_scenarios`, `get_scenario`, `expand_scenario`,
-`compare_scenarios`, `report_outcome`) expose prepared context on demand.
-`report_outcome` closes the loop by feeding scenario usefulness back into
-frontier adaptation.
+MCP tools expose Prepared Work, query resolution, scenario navigation,
+workspace goals, setup/policy controls, and Deep-Run sessions. Feedback closes
+the loop by feeding usefulness signals back into future ranking.
 
 ### Cockpit runtime (human controls)
 

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -84,7 +84,7 @@ _Released April 22, 2026 · [Details on GitHub](https://github.com/Borgels/vaner
 
 ## v0.7.0
 
-_Released April 22, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.7.0)_
+_Released April 21, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.7.0)_
 
 - ci: make windows verify non-blocking
 - fix: ship vaner 0.6.2 hardening (refresh)

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -9,6 +9,27 @@ Notable product releases are published on [**GitHub Releases**](https://github.c
 
 _The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog -- --force`._
 
+## Vaner 0.8.8
+
+_Released April 30, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.8)_
+
+- Vaner 0.8.8 focuses on prepared work quality, exact component targeting, and release-grade benchmark governance
+- Adds the Prepared Work surface, combining predictions and generated work artifacts into one cleaner user-facing feed
+- Adds WorkProduct lifecycle support for high-signal prepared artifacts such as review notes, bug hypotheses, docs drift, research briefs, and exportable virtual diffs
+- Improves exact component targeting with lightweight symbol indexing and deterministic target normalization so named functions/classes/files beat broad stale relevance
+- Tightens draft readiness: weak component matches stay evidence-only, while exact definitions, strong test+usage evidence, and explicitly docs/schema-shaped cases can become draft-ready
+- Adds schema-locked benchmark governance with stable small/medium/large profiles, release gates, reproducibility metadata, and leak scanning
+- ...and more on [GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.8).
+
+## v0.8.7
+
+_Released April 26, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.7)_
+
+- feat(0.8.7): Live Intent Capture Phase 1 + L0 Claude Code adapter + 0.8.6 carry-overs (#189) @abolsen
+- fix: resolve code scanning alerts (#188) @abolsen
+- ci: move to larger GitHub-hosted runners + quality/compatibility split (#187) @abolsen
+- @abolsen
+
 ## v0.8.6
 
 _Released April 25, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.6)_

--- a/content/docs/cli.mdx
+++ b/content/docs/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: CLI Reference
-description: Core Vaner CLI commands for MCP-first setup, cockpit, and scenarios.
+description: Core Vaner CLI commands for setup, Prepared Work, MCP, cockpit, and diagnostics.
 ---
 
 ## Recommended first-run flow
@@ -34,12 +34,29 @@ control over the engine, see [Advanced Mode](/advanced-mode).
 
 ## Advanced daemon controls
 
+Most users should use `vaner up` and `vaner down`. Use these only when you need
+separate process control:
+
 ```bash
 vaner daemon start --once false --path .
 vaner daemon serve-http --path .
 vaner daemon status --path .
 vaner daemon stop --path .
 ```
+
+## Prepared Work via HTTP/MCP
+
+Prepared Work is normally consumed through desktop, cockpit, or MCP clients.
+The daemon exposes the same surface over loopback HTTP:
+
+```bash
+curl -s http://127.0.0.1:8473/prepared-work | jq
+curl -s http://127.0.0.1:8473/work-products | jq
+```
+
+Use `vaner.prepared_work.dashboard` in MCP clients for the UI-safe card feed.
+Diagnostic clients can use `vaner.work_products.*` for inspect, export,
+dismiss, and feedback flows.
 
 ## Scenario cockpit commands
 
@@ -111,6 +128,9 @@ vaner upgrade
 vaner mcp --path .
 vaner mcp --path . --transport sse --host 127.0.0.1 --port 8472
 ```
+
+The stdio form is the default for Claude Code, Cursor, Codex CLI, VS Code,
+Windsurf, Zed, Continue, Cline, Roo, and Claude Desktop.
 
 ## Optional capability: OpenAI-compatible gateway
 

--- a/content/docs/cockpit.mdx
+++ b/content/docs/cockpit.mdx
@@ -4,15 +4,31 @@ description: Operate and inspect Vaner with live stream, status, and local UI co
 ---
 
 The cockpit is Vaner's human-control surface. Use it to monitor readiness,
-inspect scenarios, and debug local setup while your MCP clients call tools.
+inspect Prepared Work and scenarios, and debug local setup while your MCP
+clients call tools.
 
 ## Start cockpit HTTP
 
 ```bash
-vaner daemon serve-http --path .
+vaner up --path .
 ```
 
 Default URL: `http://127.0.0.1:8473`.
+
+If you need separate process control, run `vaner daemon serve-http --path .`.
+
+## Prepared Work
+
+The cockpit exposes the same Prepared Work feed as desktop and MCP clients. It
+shows UI-safe cards by default and hides internal lifecycle, self-evaluation,
+and raw ranking fields unless a diagnostic view asks for them.
+
+Useful endpoints for scripted checks:
+
+- `/prepared-work`
+- `/work-products`
+- `/work-products/{id}/inspect`
+- `/work-products/{id}/export`
 
 ## Stream live scenarios
 
@@ -21,7 +37,8 @@ vaner watch --cockpit-url http://127.0.0.1:8473
 ```
 
 This tails the cockpit SSE stream (`/scenarios/stream`) so you can watch
-precompute output in real time.
+precompute output in real time. `/events/stream` exposes the broader daemon
+event stream for model, artifact, scenario, and prediction stages.
 
 ## Open the web UI
 

--- a/content/docs/concepts.mdx
+++ b/content/docs/concepts.mdx
@@ -7,13 +7,22 @@ description: Core vocabulary used across Vaner documentation.
 - **Scenario:** candidate context branch with ranked files, evidence, and expansion metadata
 - **Frontier:** priority queue of scenarios waiting for deeper exploration
 - **Artefact:** precomputed context unit (summary/index/diff)
+- **Prepared Work:** user-facing card that Vaner prepared before the prompt,
+  with evidence, freshness, confidence, and safe actions
+- **Work Product:** internal stored artifact behind some Prepared Work cards,
+  such as review notes, bug hypotheses, docs drift notes, virtual diffs, and
+  research briefs
+- **Virtual Diff:** patch-shaped Prepared Work that can be inspected or exported
+  but is never applied automatically
+- **Prediction:** internal next-intent candidate; strong predictions can appear
+  as Prepared Work, while weaker predictions remain diagnostic
 - **Context Package:** selected and compressed artefacts for a prompt
 - **Decision Record:** persisted explanation of why Vaner picked one package over alternatives
 - **Policy:** privacy and token-budget rules
 - **Agent Skill:** `SKILL.md` playbook metadata used as an intent prior and feedback attribution signal
-- **Feedback Queue:** buffered `report_outcome` events consumed by frontier adaptation
+- **Feedback Queue:** buffered feedback events consumed by frontier adaptation
 - **Ponder Loop:** idle-time branch exploration and artifact preparation
-- **Answer Loop:** prompt-time context ranking and assembly
+- **Answer Loop:** prompt-time ranking and assembly when a client asks
 - **Frontier Scenario:** one speculative branch candidate with source, priority, and depth
 - **Conversation Arc Model:** predicts likely next intent categories from priors and user history
 - **Cockpit:** local HTTP/CLI control surface for health, stream, and inspection views

--- a/content/docs/examples.mdx
+++ b/content/docs/examples.mdx
@@ -22,4 +22,4 @@ Gateway-mode examples:
 
 Browse examples in the main repository:
 
-- [github.com/Borgels/Vaner/tree/main/examples](https://github.com/Borgels/Vaner/tree/main/examples)
+- [github.com/Borgels/vaner/tree/main/examples](https://github.com/Borgels/vaner/tree/main/examples)

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -146,6 +146,11 @@ Press `Ctrl+C` (or run `vaner down --path .`) when you are done.
 
 > Vaner is local-first. No background process runs unless you start it (`vaner up`) or your MCP client invokes it.
 
+Once running, use your desktop app, cockpit, or MCP client to inspect the
+Prepared Work feed. Vaner may prepare review notes, bug hypotheses, research
+briefs, or virtual diffs, but it does not apply changes to your files
+automatically.
+
 If nothing seems to be happening, run:
 
 ```bash

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -38,6 +38,14 @@ before installing missing prerequisites (Python 3.11+, `uv`/`pipx`), and
 installs `vaner[mcp]` so the MCP server is ready out of the box. Pass
 `--no-mcp` to skip the MCP extra.
 
+On **Windows**, install via `pip` or `pipx` directly (the bash installer
+above is POSIX-only):
+
+```powershell
+pip install "vaner[mcp]"   # or: pipx install "vaner[mcp]"
+vaner init
+```
+
 ### Non-interactive install (CI, Dockerfiles)
 
 ```bash

--- a/content/docs/human-product-proof.mdx
+++ b/content/docs/human-product-proof.mdx
@@ -1,0 +1,94 @@
+---
+title: Human Product-Proof Test
+description: A scripted check for whether people understand, trust, inspect, and safely act on Prepared Work.
+---
+
+The human product-proof test is a small, scripted check for Prepared Work. It is
+not a broad usability study and it does not replace automated E2E tests or
+benchmarks. Use it before making stronger public claims that Prepared Work is
+understandable, trusted, and useful in the app.
+
+Run 3 to 5 guided sessions against public fixture repos or public tasks only.
+Include at least one developer-like user. If the tested flow is not code-only,
+include at least one non-core user. A power user familiar with AI tools is
+optional.
+
+## Goals
+
+Validate whether participants can:
+
+- explain what a Prepared Work card is offering
+- decide whether a card looks useful
+- inspect the evidence behind a card
+- understand freshness and confidence labels
+- export or adopt without thinking Vaner silently changed files
+- dismiss irrelevant work or give feedback
+- distinguish a prepared suggestion from a completed change
+- trust that the card is based on real, inspectable evidence
+
+## Script
+
+Use the same script in every session:
+
+1. Start from a clean public fixture repo or public task.
+2. Show Vaner with 2 to 5 Prepared Work cards.
+3. Ask what each card appears to offer.
+4. Ask which card they would inspect first and why.
+5. Ask them to inspect one card.
+6. Ask what evidence supports the card.
+7. Ask whether they would export or adopt it.
+8. Ask what they expect export or adopt to do before clicking.
+9. Let them click export or adopt.
+10. Verify whether their expectation matched the result.
+11. Ask them to dismiss or give feedback on one bad or irrelevant card.
+12. Ask what felt unsafe, confusing, stale, or too technical.
+
+Do not explain internal terms unless the participant gets stuck. The test is
+checking the product surface, not whether the facilitator can teach it.
+
+## Measurements
+
+Record:
+
+- task completion: inspect, export/adopt, dismiss, and feedback without help
+- comprehension: whether the participant can explain the card
+- trust: whether they understand why Vaner suggested it
+- safety expectation: whether they know export/adopt does not silently mutate
+  repo files
+- actionability: whether they would actually use the artifact
+- confusion points: wording, labels, evidence, export/adopt behavior, and
+  client differences
+- false-positive pain: confidently wrong, stale, or irrelevant cards
+- time to first useful action
+
+## Gates
+
+Before making stronger Prepared Work product claims:
+
+- at least 80% of participants can explain what a Prepared Work card is
+- at least 80% can inspect evidence without help
+- at least 80% understand that export/adopt does not silently mutate repo files
+- no critical trust failures occur
+- no participant treats diagnostic or internal fields as product-facing concepts
+- serious confusion points are fixed or documented as known limitations
+
+## Non-goals
+
+Do not use this test to tune the engine broadly. Do not ask vague preference
+questions such as whether participants like it. Do not test private repos or
+private user data. Do not treat enthusiasm as proof; the useful signal is
+whether people understand, trust, and safely act on Prepared Work.
+
+## Report Template
+
+Use a short report with:
+
+- participants and context
+- exact fixture or task
+- cards shown
+- actions attempted
+- completion results
+- confusion points
+- trust or safety issues
+- wording fixes
+- whether Prepared Work is ready for stronger public claims

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -1,17 +1,28 @@
 ---
 title: Introduction
-description: Vaner is a local-first predictive context engine that prepares context before you ask.
+description: Vaner is a local-first preparation engine that turns idle compute into useful Prepared Work.
 ---
 
-Vaner is a **local-first predictive context engine** for AI coding workflows.
+Vaner is a **local-first preparation engine** for AI workflows.
 
-Think of it like a chess engine for context: during idle time, Vaner predicts likely next prompts, prepares useful context branches, and then serves the best package quickly when the real prompt arrives.
+It runs beside your AI client, watches the scoped project you chose, and uses
+idle time to prepare useful work before you explicitly ask for it. When you do
+ask, your client can inspect or use a small set of evidence-backed Prepared Work
+items instead of starting from a cold retrieval pass.
 
 ## What Vaner does
 
-- Runs a background **ponder loop** to pre-build likely context.
-- Runs a prompt-time **answer loop** to rank and assemble the best context package.
-- Stays **model-agnostic**, so you can use local or cloud backends without lock-in.
+- Runs a background **ponder loop** to build and refresh likely useful work.
+- Surfaces a small **Prepared Work** feed: review notes, bug hypotheses, docs
+  drift, virtual diffs, research briefs, and ready prediction-backed drafts.
+- Serves evidence-backed context over MCP to Claude Code, Cursor, Codex CLI,
+  VS Code, Zed, Windsurf, Continue, Cline, Roo, and Claude Desktop.
+- Stays **model-agnostic**, so you can use local or cloud backends without
+  lock-in.
+
+Prepared Work is non-mutating by default. Vaner may prepare a virtual diff, but
+it will not apply that patch or edit your files unless you explicitly export or
+adopt it through a client workflow.
 
 ## Core outcomes
 
@@ -24,6 +35,7 @@ Vaner is successful when it improves one or more of:
 ## Start here
 
 - New users: [Getting started](/getting-started)
+- Understand Prepared Work: [Prepared Work](/prepared-work)
 - Wire up your AI client over MCP: [Connect your client](/mcp)
 - Concepts and terminology: [Concepts](/concepts)
 - Setup and tuning: [Configuration](/configuration)

--- a/content/docs/integrations/composer-adapter.mdx
+++ b/content/docs/integrations/composer-adapter.mdx
@@ -134,7 +134,7 @@ A snapshot looks like (L0 example):
 
 ## Reference implementation
 
-The [Claude Code plugin](https://github.com/Borgels/Vaner/tree/main/plugins/vaner)
+The [Claude Code plugin](https://github.com/Borgels/vaner/tree/main/plugins/vaner)
 ships the L0 reference adapter:
 
 - `plugins/vaner/hooks/hooks.json` — `UserPromptSubmit` hook
@@ -146,9 +146,9 @@ ships the L0 reference adapter:
 ## JSON Schema
 
 The wire-contract JSON Schema is generated from the pydantic models in
-[`src/vaner/signals/composer/contract.py`](https://github.com/Borgels/Vaner/blob/main/src/vaner/signals/composer/contract.py)
+[`src/vaner/signals/composer/contract.py`](https://github.com/Borgels/vaner/blob/main/src/vaner/signals/composer/contract.py)
 and committed at
-[`docs/specs/composer-adapter.schema.json`](https://github.com/Borgels/Vaner/blob/main/docs/specs/composer-adapter.schema.json).
+[`docs/specs/composer-adapter.schema.json`](https://github.com/Borgels/vaner/blob/main/docs/specs/composer-adapter.schema.json).
 
 Adapters in non-Python languages can validate their payloads against
 this schema. CI guards drift via `git diff --exit-code` after running

--- a/content/docs/integrations/mcp.mdx
+++ b/content/docs/integrations/mcp.mdx
@@ -1,12 +1,11 @@
 ---
 title: MCP Mode
-description: Conceptual overview of Vaner's MCP integration — what tools it exposes and how clients connect.
+description: Conceptual overview of Vaner's MCP integration and current tool surface.
 ---
 
-Vaner ships an [MCP](https://modelcontextprotocol.io/) server so any
-MCP-aware IDE or agent (Claude Code, Cursor, VS Code Copilot, Codex CLI,
-Windsurf, Zed, Continue, Cline, Roo, Claude Desktop, …) can pull
-scenario-ranked context without Vaner being in the model path.
+Vaner ships an [MCP](https://modelcontextprotocol.io/) server so MCP-aware IDEs
+and agents can pull Prepared Work and evidence-backed context without putting
+Vaner in the model hot path.
 
 ## Start the server
 
@@ -17,48 +16,70 @@ vaner mcp --path .
 The server speaks stdio by default. Clients invoke `vaner mcp --path .` as a
 subprocess and communicate over their own stdin/stdout.
 
+## Recommended client behavior
+
+Normal clients should call `vaner.prepared_work.dashboard` first. It returns a
+small list of UI-safe cards and hides internal lifecycle, self-evaluation, and
+raw ranking fields.
+
+When the user inspects a card, call the action returned by that card. Do not
+infer allowed actions from type alone. Server-authoritative actions are what
+keep virtual diffs and exports non-mutating by default.
+
 ## Tools exposed
 
-Vaner's v1.0 MCP surface is namespaced (`vaner.*`). Tools break into three
-groups: resolve/navigation, predictions, and workspace goals.
-
-### Resolve & navigation
+### Prepared Work
 
 | Tool | Purpose |
 | --- | --- |
-| `vaner.status` | Health + readiness. Use as the smoke-test after wiring. |
-| `vaner.resolve` | Given a user prompt, return a prepared briefing + evidence + (optionally) a speculative draft. |
-| `vaner.suggest` | Likely next prompts based on workflow state. |
+| `vaner.prepared_work.dashboard` | Unified Prepared Work dashboard for UI-safe cards. |
+| `vaner.work_products.list` | Diagnostic list of prepared artifacts. |
+| `vaner.work_products.inspect` | Inspect body, evidence, warnings, and allowed actions. |
+| `vaner.work_products.export` | Export ready content or patch payload without applying it. |
+| `vaner.work_products.dismiss` | Hide a prepared artifact from normal feeds. |
+| `vaner.work_products.feedback` | Record usefulness feedback. |
+
+### Resolve and navigation
+
+| Tool | Purpose |
+| --- | --- |
+| `vaner.status` | Health and readiness smoke test. |
+| `vaner.resolve` | Resolve a prompt into prepared briefing, evidence, and optional draft. |
+| `vaner.suggest` | Likely next prompts or work directions. |
 | `vaner.search` | Search Vaner's scenario graph. |
-| `vaner.expand` | Deepen precompute around a specific scenario/target. |
-| `vaner.inspect` | Read a single scenario/evidence item by id. |
+| `vaner.expand` | Deepen precompute around a scenario or target. |
+| `vaner.inspect` | Inspect one scenario/evidence record. |
 | `vaner.explain` | Human-readable rationale for a resolution. |
-| `vaner.feedback` | Usefulness feedback (`useful`, `partial`, `wrong`, `irrelevant`). |
+| `vaner.feedback` | Feedback for resolution/scenario flows. |
 | `vaner.warm` | Hint Vaner to precompute around selected targets. |
+| `vaner.debug.trace` | Diagnostic trace data. |
 
-### Predictions (0.8.0)
+### Predictions and workspace goals
 
-| Tool | Purpose |
-| --- | --- |
-| `vaner.predictions.active` | List predictions currently in `ready` or `drafting` state with their labels, readiness, and compute contract. |
-| `vaner.predictions.adopt` | Adopt a specific prediction as the user's next intent. Returns a Resolution with prepared briefing + draft answer + `adopted_from_prediction_id` for provenance. |
-
-### Workspace goals (0.8.0)
-
-Long-horizon workspace aspirations ("implement JWT migration", "review auth
-before ship") that span many prompts. Declared goals seed goal-anchored
-predictions the engine matures across cycles.
+Predictions remain available for diagnostic and advanced clients, but Prepared
+Work is the normal user-facing surface.
 
 | Tool | Purpose |
 | --- | --- |
-| `vaner.goals.list` | List workspace goals filtered by status. |
-| `vaner.goals.declare` | Declare a new user-authoritative goal (`confidence=1.0`). |
-| `vaner.goals.update_status` | Move a goal between `active`/`paused`/`abandoned`/`achieved`. |
-| `vaner.goals.delete` | Delete a goal (prefer `update_status` — deletion loses evidence). |
+| `vaner.predictions.active` | List ready/drafting predictions. |
+| `vaner.predictions.adopt` | Adopt a specific prediction as the current intent. |
+| `vaner.predictions.dashboard` | Diagnostic prediction dashboard. |
+| `vaner.goals.list` | List workspace goals. |
+| `vaner.goals.declare` | Declare a new user-authoritative goal. |
+| `vaner.goals.update_status` | Move a goal between active, paused, abandoned, and achieved. |
+| `vaner.goals.delete` | Delete a goal. |
+
+### Setup, policy, sources, artifacts, and Deep-Run
+
+| Tool family | Purpose |
+| --- | --- |
+| `vaner.setup.*` | Setup questions, recommendations, apply flow, and setup status. |
+| `vaner.policy.show` | Current policy bundle and posture. |
+| `vaner.artefacts.*` | List/inspect/status/influence controls for stored artifacts. |
+| `vaner.sources.status` | Source health/status. |
+| `vaner.deep_run.*` | Start, stop, inspect, list, and default Deep-Run sessions. |
 
 All tools are scoped to the `--path` Vaner was started with.
-
-Most tools also accept an optional `skill` argument for attribution. This lets Vaner track which agent skill drove calls/outcomes and route feedback into frontier adaptation.
 
 ## Want to wire it up?
 
@@ -68,8 +89,8 @@ Most tools also accept an optional `skill` argument for attribution. This lets V
 
 ## When to use MCP vs other modes
 
-- **MCP mode** (this page): your IDE already orchestrates model calls and only
-  needs Vaner-provided context. Lowest coupling; recommended default.
+- **MCP mode**: your IDE orchestrates model calls and needs Vaner-provided
+  Prepared Work/context. Recommended default.
 - **[Proxy mode](/integrations/proxy)**: tools that only speak the OpenAI
   `/v1/chat/completions` shape.
 - **[Context-only mode](/integrations/context-only)**: frameworks that call

--- a/content/docs/integrations/tools/claude-code-mcp.mdx
+++ b/content/docs/integrations/tools/claude-code-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Claude Code to Vaner over MCP for predictive, repo-grounded
 
 [Claude Code](https://docs.anthropic.com/en/docs/claude-code/mcp) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,9 @@ vaner init --path .
 
 ## Verify
 
-Run `/mcp` inside a Claude Code session — `vaner` should appear with the five scenario tools.
+Run `/mcp` inside a Claude Code session. `vaner` should appear with
+`vaner.status`, `vaner.prepared_work.dashboard`, and the rest of the current
+tool surface.
 
 If `Claude Code` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,7 +36,8 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Scope `/tmp` work to your repo: Claude Code hits Vaner for `list_scenarios` before running its own tools.
+- Scope work to your repo: Claude Code can inspect `vaner.prepared_work.dashboard`
+  before running its own tools.
 - Switch between `user` / `project` / `local` scope without editing JSON by hand.
 - Tight loop with `claude --resume` — Vaner keeps the ponder cache between sessions.
 

--- a/content/docs/integrations/tools/claude-desktop-mcp.mdx
+++ b/content/docs/integrations/tools/claude-desktop-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Claude Desktop to Vaner over MCP for predictive, repo-groun
 
 [Claude Desktop](https://modelcontextprotocol.io/quickstart/user) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,9 @@ vaner init --path .
 
 ## Verify
 
-Quit and reopen Claude Desktop. The hammer icon should list `vaner` with its five scenario tools.
+Quit and reopen Claude Desktop. The hammer icon should list `vaner` with
+`vaner.status`, `vaner.prepared_work.dashboard`, and the rest of the current
+tool surface.
 
 If `Claude Desktop` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -35,7 +37,8 @@ missing backend API key — confirm with `vaner config show`.
 ## What this unlocks
 
 - Chat with Claude Desktop about a repo without SSH-ing anywhere: Vaner mounts it via MCP.
-- Hammer menu lists every Vaner scenario tool with inline descriptions.
+- Hammer menu lists Vaner's Prepared Work, resolve, setup, and diagnostic tools
+  with inline descriptions.
 - Toggle off anytime by removing the `vaner` entry from `claude_desktop_config.json`.
 
 ## See also

--- a/content/docs/integrations/tools/cline-mcp.mdx
+++ b/content/docs/integrations/tools/cline-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Cline to Vaner over MCP for predictive, repo-grounded conte
 
 [Cline](https://docs.cline.bot/mcp/adding-and-configuring-servers) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,8 @@ vaner init --path .
 
 ## Verify
 
-Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.
+Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run
+`vaner.status` from the chat.
 
 If `Cline` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a

--- a/content/docs/integrations/tools/codex-cli-mcp.mdx
+++ b/content/docs/integrations/tools/codex-cli-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Codex CLI to Vaner over MCP for predictive, repo-grounded c
 
 [Codex CLI](https://github.com/openai/codex) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -34,9 +34,10 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Feed Vaner context to Codex CLI sessions: `codex exec "refactor X"` can call `list_scenarios` and `get_scenario` first.
+- Feed Vaner context to Codex CLI sessions: `codex exec "refactor X"` can call
+  `vaner.prepared_work.dashboard` or `vaner.resolve` first.
 - Pin a per-repo backend in `~/.codex/config.toml` alongside the Vaner entry.
-- Pair with `vaner daemon start` to keep ponder warm between CLI invocations.
+- Pair with `vaner up --path .` to keep ponder warm between CLI invocations.
 
 ## See also
 

--- a/content/docs/integrations/tools/continue-mcp.mdx
+++ b/content/docs/integrations/tools/continue-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Continue to Vaner over MCP for predictive, repo-grounded co
 
 [Continue](https://docs.continue.dev/customize/deep-dives/mcp) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,8 @@ vaner init --path .
 
 ## Verify
 
-Reload Continue. Ask the agent to list available MCP tools — `vaner.list_scenarios` should be present.
+Reload Continue. Ask the agent to list available MCP tools; `vaner.status` and
+`vaner.prepared_work.dashboard` should be present.
 
 If `Continue` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,9 +35,11 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Continue’s agent mode calls `vaner.list_scenarios` between steps for grounded plans.
+- Continue's agent mode can call `vaner.prepared_work.dashboard` between steps
+  for grounded plans.
 - Ship the YAML in `.continue/` so teammates inherit the integration.
-- Combine with Continue’s code lenses to open `vaner.get_scenario` payloads inline.
+- Combine with Continue's code lenses to inspect exported Prepared Work payloads
+  inline.
 
 ## See also
 

--- a/content/docs/integrations/tools/cursor-mcp.mdx
+++ b/content/docs/integrations/tools/cursor-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Cursor to Vaner over MCP for predictive, repo-grounded cont
 
 [Cursor](https://docs.cursor.com/en/context/mcp) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,9 @@ vaner init --path .
 
 ## Verify
 
-Restart Cursor, open Settings → MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.
+Restart Cursor, open Settings -> MCP, confirm `vaner` is listed. Run
+`vaner.status` or `vaner.prepared_work.dashboard` from the composer to
+smoke-test.
 
 If `Cursor` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,9 +36,11 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Composer can call `list_scenarios`/`get_scenario` for "where is X?" prompts instead of grepping from scratch.
+- Composer can call `vaner.prepared_work.dashboard` or `vaner.resolve` for
+  "where is X?" prompts instead of grepping from scratch.
 - Project-scoped config keeps Vaner active only in the repos you want.
-- Agent mode can compare alternatives with `compare_scenarios` and close the loop with `report_outcome`.
+- Agent mode can inspect evidence and close the loop with `vaner.feedback` or
+  `vaner.work_products.feedback`.
 
 ## See also
 

--- a/content/docs/integrations/tools/roo-mcp.mdx
+++ b/content/docs/integrations/tools/roo-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Roo Code to Vaner over MCP for predictive, repo-grounded co
 
 [Roo Code](https://docs.roocode.com/features/mcp/using-mcp-in-roo) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,8 @@ vaner init --path .
 
 ## Verify
 
-Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.
+Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run
+`vaner.status`.
 
 If `Roo Code` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a
@@ -34,7 +35,8 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Roo Code’s agent mode can call `list_scenarios`/`get_scenario` before writing diffs.
+- Roo Code's agent mode can call `vaner.prepared_work.dashboard` before writing
+  diffs.
 - Project-level `.roo/mcp.json` so repos opt in explicitly.
 - Works with Roo’s orchestration to break large changes into Vaner-informed steps.
 

--- a/content/docs/integrations/tools/vscode-copilot-mcp.mdx
+++ b/content/docs/integrations/tools/vscode-copilot-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect VS Code (Copilot) to Vaner over MCP for predictive, repo-gr
 
 [VS Code (Copilot)](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -26,7 +26,8 @@ vaner init --path .
 
 ## Verify
 
-Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.
+Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server
+from the tools menu and call `vaner.status`.
 
 If `VS Code (Copilot)` reports the server as failed, run `vaner mcp --path .`
 manually in a terminal and read the error. The most common failure is a

--- a/content/docs/integrations/tools/windsurf-mcp.mdx
+++ b/content/docs/integrations/tools/windsurf-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Windsurf to Vaner over MCP for predictive, repo-grounded co
 
 [Windsurf](https://docs.windsurf.com/windsurf/cascade/mcp) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.
@@ -34,7 +34,8 @@ missing backend API key — confirm with `vaner config show`.
 
 ## What this unlocks
 
-- Cascade pulls Vaner scenarios before drafting a plan, reducing thrash on large repos.
+- Cascade can inspect Prepared Work before drafting a plan, reducing thrash on
+  large repos.
 - Works alongside Windsurf’s built-in memory — Vaner supplies the structural context.
 - Switch repos without restarting Windsurf; Vaner scopes itself to `--path`.
 

--- a/content/docs/integrations/tools/zed-mcp.mdx
+++ b/content/docs/integrations/tools/zed-mcp.mdx
@@ -5,8 +5,8 @@ description: Connect Zed to Vaner over MCP for predictive, repo-grounded context
 
 [Zed](https://zed.dev/docs/assistant/model-context-protocol) supports the
 [Model Context Protocol](https://modelcontextprotocol.io/) out of the box.
-Point it at `vaner mcp` and Vaner will serve scenario-ranked context to your
-agent before every prompt.
+Point it at `vaner mcp` and Vaner will serve Prepared Work and
+scenario-ranked context to your agent.
 
 > [!TIP]
 > Or just run `vaner init --path .` from your project root — it will detect and configure this client for you.

--- a/content/docs/mcp/index.mdx
+++ b/content/docs/mcp/index.mdx
@@ -3,19 +3,21 @@ title: Connect your AI client
 description: Install Vaner, pick a model backend, and wire up MCP for Claude Code, Cursor, VS Code, Codex, Windsurf, Zed, Continue, Cline, Roo, and Claude Desktop.
 ---
 
-Vaner exposes your repository to AI clients over the
+Vaner exposes Prepared Work and evidence-backed context to AI clients over the
 [Model Context Protocol](https://modelcontextprotocol.io/). Most clients can
 launch Vaner directly via `uvx` when `uvx` is available, so you can connect
-first and install the full CLI later only if you want it. Three steps:
+first and install the full CLI later only if you want it.
 
 > [!TIP]
 > Most users do not need manual MCP setup. Run `vaner init --path .` and Vaner
 > configures supported clients automatically. This page is mainly for custom or
 > unsupported client setups.
 
-1. Connect your client (default: `uvx` launcher, no permanent install).
+Three steps:
+
+1. Connect your client.
 2. Pick the model backend Vaner should ponder with.
-3. Use the MCP tools from your AI client.
+3. Use the Prepared Work and context tools from your AI client.
 
 ## 1. Install once, then wire clients
 
@@ -79,67 +81,103 @@ Common paths include:
 - `.cursor/skills/vaner/vaner-feedback/SKILL.md`
 - `.claude/skills/vaner/vaner-feedback/SKILL.md`
 
-This is effectively a system-prompt-level instruction for agent runtimes: after
-using Vaner scenarios, report outcomes back via `report_outcome` so ranking can
-improve over time. See [Agent Skills](/skills) for the full loop.
+This is system-prompt-level guidance for agent runtimes: after using Vaner,
+report outcomes back so ranking can improve over time. See
+[Agent Skills](/skills) for the full loop.
 
 ## Optional: bound ponder time
 
-Vaner will happily ponder forever. If you want a hard cap — per cycle or per
-session — set the compute budget below:
+Vaner can ponder continuously while it is running. If you want a hard cap per
+cycle or per session, set the compute budget below:
 
 <ComputeBudget />
 
-- `max_cycle_seconds` bounds a single precompute cycle (default `300`).
-- `max_session_minutes` bounds a continuous `vaner daemon` run (default unset).
+- `max_cycle_seconds` bounds a single precompute cycle.
+- `max_session_minutes` bounds a continuous `vaner up` / daemon run.
 
 Both are safe to leave at their defaults; set them if you want Vaner to stop
-pondering after, say, 30 minutes on battery.
+pondering after a fixed wall-clock budget.
 
 ## What Vaner's MCP server exposes
 
-When your client connects to `vaner mcp`, it gets a set of namespaced tools.
-The core surface:
+When your client connects to `vaner mcp`, it gets namespaced `vaner.*` tools.
+The current surface is grouped by user-facing purpose.
 
-- `vaner.status` — health + readiness. Use this as your smoke-test after wiring.
-- `vaner.resolve` — given a user prompt, return a prepared briefing + evidence
-  + (optionally) a speculative draft answer.
-- `vaner.suggest` — suggest likely next prompts based on workflow state.
+### Prepared Work
+
+Use these first in normal clients:
+
+- `vaner.prepared_work.dashboard` — UI-safe cards combining Prepared Work
+  artifacts and ready prediction-backed opportunities.
+- `vaner.work_products.list` — diagnostic list of Vaner-owned prepared
+  artifacts.
+- `vaner.work_products.inspect` — inspect one artifact with body, evidence,
+  warnings, and allowed actions.
+- `vaner.work_products.export` — export one artifact only when it is
+  exportable. This returns content and never edits files.
+- `vaner.work_products.dismiss` — hide one item from normal feeds.
+- `vaner.work_products.feedback` — record `useful`, `partial`, `irrelevant`,
+  or `not_useful` feedback.
+
+### Resolve and navigation
+
+- `vaner.status` — health and readiness smoke test.
+- `vaner.resolve` — resolve a user query into a briefing, evidence, and optional
+  draft.
+- `vaner.suggest` — suggest likely next prompts or work directions.
 - `vaner.search` / `vaner.expand` / `vaner.inspect` — navigate and deepen the
-  prepared scenario graph.
-- `vaner.explain` — human-readable rationale for why a resolution surfaced.
-- `vaner.feedback` — usefulness feedback (`useful`, `partial`, `wrong`,
-  `irrelevant`) so Vaner adapts.
+  scenario graph.
+- `vaner.explain` — explain why a resolution surfaced.
+- `vaner.feedback` — usefulness feedback for resolution/scenario flows.
 - `vaner.warm` — hint Vaner to precompute around specific targets.
+- `vaner.debug.trace` — diagnostic trace data for debugging.
 
-**0.8.0 adds two new tool families:**
+### Predictions and goals
 
-- `vaner.predictions.active` / `vaner.predictions.adopt` — list Vaner's
-  currently-ready next-prompt predictions and adopt one. Adopt serves the
-  prepared briefing + draft answer with `adopted_from_prediction_id` for
-  provenance, so your client can surface an answer instantly instead of
-  round-tripping to the frontier model.
-- `vaner.goals.list` / `vaner.goals.declare` / `vaner.goals.update_status` /
-  `vaner.goals.delete` — workspace-level goals that span many prompts
-  (e.g. "JWT migration"). Declared goals seed long-horizon predictions the
-  engine matures across successive cycles.
+Predictions are mostly internal machinery. Use Prepared Work for normal UI.
 
-Most tools also accept an optional `skill` field for attribution when a
-specific `SKILL.md` drove the call.
+- `vaner.predictions.active`
+- `vaner.predictions.adopt`
+- `vaner.predictions.dashboard`
+- `vaner.goals.list`
+- `vaner.goals.declare`
+- `vaner.goals.update_status`
+- `vaner.goals.delete`
 
-See [Concepts](/concepts) and [Architecture](/architecture) for the full picture.
+### Artifacts, sources, setup, and Deep-Run
+
+- `vaner.artefacts.list`
+- `vaner.artefacts.inspect`
+- `vaner.artefacts.set_status`
+- `vaner.artefacts.influence`
+- `vaner.sources.status`
+- `vaner.setup.questions`
+- `vaner.setup.recommend`
+- `vaner.setup.apply`
+- `vaner.setup.status`
+- `vaner.policy.show`
+- `vaner.deep_run.start`
+- `vaner.deep_run.stop`
+- `vaner.deep_run.status`
+- `vaner.deep_run.list`
+- `vaner.deep_run.show`
+- `vaner.deep_run.defaults`
+
+All tools are scoped to the `--path` Vaner was started with. Most tools also
+accept optional attribution fields so clients can report which skill or surface
+drove the call.
 
 ## Troubleshooting
 
-- **`vaner: command not found`** — the installer didn't add pipx's bin dir.
+- **`vaner: command not found`** — the installer did not add pipx's bin dir.
   Run `pipx ensurepath` or restart your shell.
-- **Client shows `vaner` as `failed`** — run `vaner mcp --path .` in a
-  terminal and read the error. The most common cause is a missing backend
-  key; confirm with `vaner config show`.
+- **Client shows `vaner` as failed** — run `vaner mcp --path .` in a terminal
+  and read the error. The most common cause is a missing backend key; confirm
+  with `vaner config show`.
 - **`vaner mcp` exits immediately** — your client may not be sending over
   stdio. Double-check `"type": "stdio"` in the client config.
 - **Backend not reachable** — confirm with
   `curl -s $BASE_URL/models` (OpenAI-compatible backends expose `/v1/models`).
 
-Stuck? Open an issue with `vaner diagnose --path .` output at
+Stuck? Open an issue with `vaner doctor --path .` output at
 [github.com/Borgels/vaner/issues](https://github.com/Borgels/vaner/issues).

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -6,6 +6,7 @@
     "simple-mode",
     "advanced-mode",
     "prepared-work",
+    "human-product-proof",
     "usage",
     "ai-prompts",
     "troubleshooting",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -5,6 +5,7 @@
     "getting-started",
     "simple-mode",
     "advanced-mode",
+    "prepared-work",
     "usage",
     "ai-prompts",
     "troubleshooting",

--- a/content/docs/prepared-work.mdx
+++ b/content/docs/prepared-work.mdx
@@ -1,0 +1,77 @@
+---
+title: Prepared Work
+description: The user-facing surface for work Vaner prepared before you asked.
+---
+
+Prepared Work is Vaner's main product surface. It combines concrete artifacts
+prepared during idle/background time with strong ready predictions, then shows
+only the small set that is useful enough to inspect.
+
+Users should not need to know whether an item came from a prediction, a
+WorkProduct loop, a virtual diff generator, or a research brief generator. The
+surface answers four questions:
+
+- What did Vaner prepare?
+- Why did Vaner prepare it now?
+- What evidence supports it?
+- What safe action can I take?
+
+## What can appear
+
+Prepared Work cards may represent:
+
+- review notes
+- bug hypotheses
+- docs drift notes
+- virtual diffs
+- research briefs
+- ready draft/prediction opportunities
+
+Vaner intentionally shows fewer, stronger items. Candidate, hidden, stale,
+dismissed, expired, and superseded artifacts stay out of the normal feed.
+
+## Actions
+
+Each card carries server-authoritative actions. Clients should render only the
+actions returned by Vaner:
+
+- **Inspect** opens the full rationale, evidence, warnings, and preview.
+- **Export** returns Vaner-owned content, such as markdown or a patch payload.
+- **Adopt** uses a ready prediction/package as the user's current intent.
+- **Dismiss** hides the item from normal feeds.
+- **Feedback** records whether the item was useful, partial, irrelevant, or not
+  useful.
+
+Export and adopt are explicit user actions. Vaner does not silently apply
+patches or edit project files.
+
+## Virtual diffs
+
+Virtual diffs are stored artifacts, not automatic code changes. They include
+the target files, source snapshot, rationale, evidence, and export payload.
+
+A virtual diff becomes stale when its target files no longer match the recorded
+snapshot. Stale virtual diffs are blocked from export until regenerated.
+
+## HTTP and MCP
+
+HTTP:
+
+- `GET /prepared-work`
+- `GET /work-products`
+- `GET /work-products/{id}/inspect`
+- `POST /work-products/{id}/export`
+- `POST /work-products/{id}/dismiss`
+- `POST /work-products/{id}/feedback`
+
+MCP:
+
+- `vaner.prepared_work.dashboard`
+- `vaner.work_products.list`
+- `vaner.work_products.inspect`
+- `vaner.work_products.export`
+- `vaner.work_products.dismiss`
+- `vaner.work_products.feedback`
+
+The default Prepared Work dashboard hides internal lifecycle, self-evaluation,
+and raw ranking fields. Diagnostic clients can opt into diagnostic references.

--- a/content/docs/prepared-work.mdx
+++ b/content/docs/prepared-work.mdx
@@ -75,3 +75,6 @@ MCP:
 
 The default Prepared Work dashboard hides internal lifecycle, self-evaluation,
 and raw ranking fields. Diagnostic clients can opt into diagnostic references.
+
+Before making stronger product claims, run the scripted
+[human product-proof test](/human-product-proof) against public fixtures.

--- a/content/docs/security.mdx
+++ b/content/docs/security.mdx
@@ -10,6 +10,8 @@ Vaner defaults to a conservative posture:
 - Explicit repository scope (`vaner init --path`)
 - Exclusion patterns for sensitive files
 - Inspectable context decisions via `vaner inspect --last`
+- Non-mutating Prepared Work by default: virtual diffs and exports require
+  explicit user action and are never auto-applied to project files
 - Local retention controls via `vaner forget`
 - Skill discovery defaults to repo-local roots (`.cursor/skills/**`, `.claude/skills/**`, `skills/**`)
 - Privacy zoning for skills (`project_local` for repo paths, `external` for outside paths)

--- a/content/docs/simple-mode.mdx
+++ b/content/docs/simple-mode.mdx
@@ -29,7 +29,7 @@ From the desktop app:
 
 - **macOS** — Vaner Companion → "Open setup wizard" in Onboarding,
   or Preferences → Engine → "Switch to Simple".
-- **Linux** — Vaner Desktop → first-run `/setup` route, or
+- **Linux / Windows** — Vaner Desktop → first-run `/setup` route, or
   Preferences → Engine → Simple tab.
 
 ## The five questions

--- a/content/docs/skills.mdx
+++ b/content/docs/skills.mdx
@@ -20,7 +20,7 @@ graph LR
     Features[extract_hybrid_features]
     Frontier[ExplorationFrontier]
     Scen[ScenarioStore]
-    MCP["report_outcome (skill)"]
+    MCP["vaner.feedback / work_products.feedback"]
     Dist[distill_skill_CLI]
     Dec[DecisionRecord]
   end
@@ -76,7 +76,8 @@ vaner:
 - `.cursor/skills/vaner/vaner-feedback/SKILL.md`
 - `.claude/skills/vaner/vaner-feedback/SKILL.md`
 
-It teaches agents to close the loop with `report_outcome`.
+It teaches agents to close the loop with `vaner.feedback` and
+`vaner.work_products.feedback`.
 
 ## Distill a skill from a decision
 

--- a/content/docs/troubleshooting.mdx
+++ b/content/docs/troubleshooting.mdx
@@ -88,6 +88,25 @@ Fix checklist:
 3. Verify with `vaner doctor --path .` and look for MCP-related checks.
 4. Prompt explicitly once: \"use the vaner MCP tools for this task\".
 
+## Prepared Work looks empty
+
+Symptom:
+
+- `/prepared-work` or the desktop Prepared Work feed returns no cards.
+
+Fix:
+
+```bash
+vaner up --path .
+vaner doctor --path .
+curl -s http://127.0.0.1:8473/status | jq
+```
+
+An empty feed is valid when Vaner has no strong, fresh item to show. Weak
+candidate artifacts and stale virtual diffs are intentionally hidden from the
+normal feed. Run a longer session, declare a goal, or use `vaner.warm` from an
+MCP client to steer preparation toward active work.
+
 ## Ollama errors or 404 responses
 
 Symptom:

--- a/content/docs/usage.mdx
+++ b/content/docs/usage.mdx
@@ -1,18 +1,18 @@
 ---
 title: Usage
-description: Day-to-day Vaner workflow with MCP tools, background pondering, and feedback loops.
+description: Day-to-day Vaner workflow with Prepared Work, MCP tools, background pondering, and feedback loops.
 ---
 
-Vaner works best when you treat it as a continuously learning context service for
-your repo: keep it running during active sessions, call MCP tools when needed,
-and report outcomes so ranking improves over time.
+Vaner works best when you treat it as a continuously running preparation service
+for your repo: keep it running during active sessions, inspect Prepared Work
+when it appears, and report outcomes so ranking improves over time.
 
 ## Daily workflow
 
 ```bash
 vaner up --path .
 vaner status --path .
-# work in your client with Vaner MCP tools
+# work in your client with Vaner MCP tools and Prepared Work
 vaner down --path .
 ```
 
@@ -26,23 +26,40 @@ If behavior seems off, run:
 vaner doctor --path .
 ```
 
+## Prepared Work first
+
+The normal product surface is Prepared Work. Your desktop app, cockpit, or MCP
+client can show cards for work Vaner has already prepared:
+
+- review notes and bug hypotheses
+- docs drift notes
+- virtual diffs
+- research briefs
+- ready prediction-backed drafts
+
+Inspect a card to see why Vaner prepared it, which evidence it used, and whether
+it is fresh enough to export or adopt. Export and adopt are explicit actions;
+Vaner does not apply patches or edit files automatically.
+
 ## How MCP usage fits in
 
 During a coding session, your client calls Vaner MCP tools such as:
 
-- `list_scenarios`
-- `get_scenario`
-- `expand_scenario`
-- `compare_scenarios`
-- `report_outcome`
+- `vaner.prepared_work.dashboard`
+- `vaner.work_products.inspect`
+- `vaner.work_products.export`
+- `vaner.resolve`
+- `vaner.feedback`
 
-Vaner serves prepared scenario context from the local store and keeps refining
-future ranking with outcome feedback.
+Diagnostic clients can still call scenario, prediction, goal, artifact, setup,
+and Deep-Run tools directly. Normal clients should prefer the Prepared Work
+dashboard because it hides lifecycle and scoring internals.
 
 ## Ponder loop vs answer loop
 
-- **Ponder loop (background):** precomputes and refreshes scenario candidates.
-- **Answer loop (prompt-time):** serves and ranks scenarios when the client asks.
+- **Ponder loop (background):** precomputes and refreshes likely useful work.
+- **Answer loop (prompt-time):** serves and ranks prepared context when the
+  client asks.
 
 This split is why Vaner can stay responsive during prompts while still doing
 deeper exploration between prompts.
@@ -52,6 +69,7 @@ deeper exploration between prompts.
 When you run `vaner init`, Vaner can install a managed `vaner-feedback` skill in
 supported client skill roots. That skill acts as system-prompt guidance so the
 agent reports outcome quality (`useful`, `partial`, `irrelevant`) after it uses
-Vaner scenarios.
+Vaner tools or Prepared Work.
 
-That closed loop improves which scenarios are ranked first in later sessions.
+That closed loop improves which prepared items and context packages rank first
+in later sessions.

--- a/public/mcp-clients.json
+++ b/public/mcp-clients.json
@@ -69,7 +69,7 @@
           "project": ".cursor/mcp.json"
         }
       },
-      "verify": "Restart Cursor, open Settings \u2192 MCP, confirm `vaner` is listed. Run the `list_scenarios` tool from the composer to smoke-test.",
+      "verify": "Restart Cursor, open Settings \u2192 MCP, confirm `vaner` is listed. Run the `vaner.status` tool from the composer to smoke-test.",
       "docsSlug": "cursor-mcp",
       "sourceUrl": "https://docs.cursor.com/en/context/mcp",
       "launchers": {
@@ -114,7 +114,7 @@
           "project": ".vscode/mcp.json"
         }
       },
-      "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `list_scenarios`.",
+      "verify": "Reload the VS Code window. In the Copilot chat view, pick the `vaner` MCP server from the tools menu and call `vaner.status`.",
       "docsSlug": "vscode-copilot-mcp",
       "sourceUrl": "https://code.visualstudio.com/docs/copilot/chat/mcp-servers",
       "launchers": {
@@ -231,7 +231,7 @@
           "user": "~/.continue/mcpServers/vaner.yaml"
         }
       },
-      "verify": "Reload Continue. Ask the agent to list available MCP tools \u2014 `vaner.list_scenarios` should be present.",
+      "verify": "Reload Continue. Ask the agent to list available MCP tools \u2014 `vaner.status` should be present.",
       "docsSlug": "continue-mcp",
       "sourceUrl": "https://docs.continue.dev/customize/deep-dives/mcp",
       "launchers": {
@@ -342,7 +342,7 @@
         "language": "json",
         "snippet": "{\n  \"mcpServers\": {\n    \"vaner\": {\n      \"command\": \"{launcherCommand}\",\n      \"args\": {launcherArgsJsonWithDotPath}\n    }\n  }\n}\n"
       },
-      "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `list_scenarios` from the chat.",
+      "verify": "Reload VS Code. In Cline's MCP Servers panel, toggle `vaner` on and run `vaner.status` from the chat.",
       "docsSlug": "cline-mcp",
       "sourceUrl": "https://docs.cline.bot/mcp/adding-and-configuring-servers",
       "launchers": {
@@ -387,7 +387,7 @@
           "user": "~/.roo/mcp_settings.json"
         }
       },
-      "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `list_scenarios`.",
+      "verify": "Reload VS Code. Open Roo Code's MCP panel and confirm `vaner` appears; run `vaner.status`.",
       "docsSlug": "roo-mcp",
       "sourceUrl": "https://docs.roocode.com/features/mcp/using-mcp-in-roo",
       "launchers": {

--- a/scripts/sync-changelog-from-github.mjs
+++ b/scripts/sync-changelog-from-github.mjs
@@ -135,6 +135,7 @@ function formatReleasesMdx(releases, repo) {
     const title = String(rawTitle).replace(/\s+/g, ' ').trim();
     const date = r.published_at
       ? new Date(r.published_at).toLocaleDateString('en-US', {
+          timeZone: 'UTC',
           year: 'numeric',
           month: 'long',
           day: 'numeric',


### PR DESCRIPTION
## Summary\n- Reframe docs around Prepared Work as the primary user-facing surface.\n- Add a Prepared Work page and update MCP, usage, architecture, cockpit, troubleshooting, security, and per-client integration docs.\n- Regenerate MCP client manifest and normalize lowercase repo links.\n\n## Verification\n- npm run sync:mcp-manifest\n- npm run build\n- public stale/leak scan for local paths/private wording