### PR TITLE
docs: add Supported hardware page

### DIFF
--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -19,6 +19,7 @@
     "cli",
     "configuration",
     "backends",
+    "supported-hardware",
     "policy-bundles",
     "hardware-tiers",
     "architecture",

--- a/content/docs/supported-hardware.mdx
+++ b/content/docs/supported-hardware.mdx
@@ -15,7 +15,7 @@ on the hardware it detects. You can override the model later via
 
 Compute Capability ≥ 5.0 is supported. Most consumer cards from the
 GTX 10-series (Pascal) onward and every RTX card qualify. See the
-official [Ollama NVIDIA list](https://github.com/ollama/ollama/blob/main/docs/gpu.md#nvidia)
+official [Ollama NVIDIA list](https://docs.ollama.com/gpu)
 for the full per-architecture matrix.
 
 | VRAM | Practical model size | Examples |
@@ -34,7 +34,7 @@ hardware tier.
 Vaner inherits Ollama's ROCm support on Linux. A subset of cards from
 the RX 6000-series onward work natively; older cards or unsupported
 SKUs fall back to CPU. See the official
-[Ollama AMD list](https://github.com/ollama/ollama/blob/main/docs/gpu.md#amd-radeon)
+[Ollama AMD list](https://docs.ollama.com/gpu)
 for the canonical per-card status.
 
 | VRAM | Practical model size |

--- a/content/docs/supported-hardware.mdx
+++ b/content/docs/supported-hardware.mdx
@@ -1,0 +1,106 @@
+---
+title: Supported hardware
+description: Vaner runs everywhere Ollama runs. Practical guide to which GPU, CPU, and platform combinations work, and which model size to expect on each tier.
+---
+
+Vaner uses [Ollama](https://ollama.com) as its default local runtime,
+so **Vaner runs everywhere Ollama runs**. If your machine can pull and
+run a model with `ollama run`, Vaner can use it.
+
+The defaults the Vaner Desktop app picks are tuned to fit comfortably
+on the hardware it detects. You can override the model later via
+`vaner config set backend.model <id>`.
+
+## NVIDIA GPUs
+
+Compute Capability ≥ 5.0 is supported. Most consumer cards from the
+GTX 10-series (Pascal) onward and every RTX card qualify. See the
+official [Ollama NVIDIA list](https://github.com/ollama/ollama/blob/main/docs/gpu.md#nvidia)
+for the full per-architecture matrix.
+
+| VRAM | Practical model size | Examples |
+|---|---|---|
+| 4–8 GB | up to ~4B params, Q4 | Qwen 3 4B, Gemma 4 (small) |
+| 8–16 GB | up to ~8B params, Q4 | Qwen 3.5 8B |
+| 16–24 GB | up to ~14B params, Q4 | Qwen 3-Coder Next |
+| 24 GB+ | up to ~30B params, Q4 | Qwen 3.5 / 3.6 (mid), Llama 4 Scout |
+
+Multi-GPU is supported via Ollama's default placement; Vaner doesn't
+override it. Vaner picks the highest-VRAM device when reporting the
+hardware tier.
+
+## AMD GPUs (ROCm)
+
+Vaner inherits Ollama's ROCm support on Linux. A subset of cards from
+the RX 6000-series onward work natively; older cards or unsupported
+SKUs fall back to CPU. See the official
+[Ollama AMD list](https://github.com/ollama/ollama/blob/main/docs/gpu.md#amd-radeon)
+for the canonical per-card status.
+
+| VRAM | Practical model size |
+|---|---|
+| 8–16 GB | up to ~8B params, Q4 |
+| 16–24 GB | up to ~14B params, Q4 |
+| 24 GB+ | up to ~30B params, Q4 |
+
+Windows ROCm support depends on the driver/HSA combo your card uses;
+treat as best-effort.
+
+## Apple Silicon
+
+M1 and later are fully supported via Metal. Unified memory is the
+constraint — the model has to fit in shared system RAM, with headroom
+for macOS itself.
+
+| Unified memory | Practical model size |
+|---|---|
+| 8 GB | up to ~3B params, Q4 (tight; expect swap) |
+| 16 GB | up to ~7B params, Q4 |
+| 32 GB | up to ~14B params, Q4 |
+| 64 GB+ | up to ~30B params, Q4 |
+
+The Vaner Desktop app for macOS picks defaults based on your machine's
+total memory and reserves a sensible chunk for the OS.
+
+## CPU-only
+
+Vaner runs on CPU when no supported accelerator is detected. Reasonable
+for small models (≤ 4B params, Q4); larger models thrash and you'll
+notice it.
+
+| RAM | Practical model size | Notes |
+|---|---|---|
+| 8–16 GB | up to ~3B params | Slow but usable for `vaner.suggest` / short prompts |
+| 16–32 GB | up to ~7B params | Acceptable latency for non-interactive precompute |
+| 32 GB+ | up to ~14B params | Still slower than the smallest GPU; consider an external GPU box |
+
+If you'll run on CPU, set the compute preset to `background` in
+`.vaner/config.toml` so Vaner only uses idle cycles:
+
+```toml
+[compute]
+preset = "background"
+```
+
+## Platforms
+
+| OS | Status |
+|---|---|
+| Linux (Ubuntu, Fedora, Debian, Arch) | Supported. Wayland and X11 both work — there's no Vaner-side difference. |
+| macOS 13+ | Supported (Apple Silicon native, Intel via Rosetta — Apple Silicon recommended). |
+| Windows 10/11 | Supported via the [Vaner Desktop installer](https://vaner.ai). |
+
+## What if my GPU isn't on Ollama's list?
+
+Two paths:
+
+1. **Run Vaner on a different machine.** The daemon is remote-friendly
+   — `vaner up` on a beefy box, point your AI client at its
+   loopback URL via SSH tunnel, done. See
+   [Backends](/backends) for the configuration.
+2. **Use a cloud backend.** OpenAI / Anthropic / OpenRouter all work
+   the same way through MCP. Vaner Desktop's setup wizard exposes
+   them as backend presets.
+
+Either way, the Vaner CLI and MCP surface are unchanged. The only
+thing different is which GPU does the inference.


### PR DESCRIPTION
## Summary

Concrete answer to *"can my machine run Vaner?"* — modeled on [docs.ollama.com/gpu](https://docs.ollama.com/gpu). Since Vaner uses Ollama as the default local runtime, support inherits from there; this page makes that explicit and gives users one table per accelerator class with the practical model sizes that fit each VRAM tier.

## Sections

- **NVIDIA** — Compute Capability ≥ 5.0; VRAM-tiered model sizing (4-8 GB → 8-16 GB → 16-24 GB → 24 GB+)
- **AMD ROCm** — defers to Ollama's per-card matrix; Windows flagged as best-effort
- **Apple Silicon** — M1+ via Metal; unified-memory tiers 8 GB → 64 GB+
- **CPU-only** — usable for ≤4B-param models; recommends the \`background\` compute preset
- **Platforms** — Linux (Wayland and X11), macOS 13+, Windows
- **Fallback paths** — remote daemon over SSH, cloud backend

Lands under **Reference → Supported hardware** in the sidebar, adjacent to the existing \`hardware-tiers\` page (conceptual tier model: light / capable / high_performance) — the two complement each other.

## Verification

- [x] \`npm run build\` clean — 42 paths, +1 from this PR
- [x] No "tested by Vaner team on X" annotations (per the call)
- [x] Cross-links resolve (Backends, Vaner Desktop download)

🤖 Generated with [Claude Code](https://claude.com/claude-code)