### PR TITLE
docs: lift /developers card-grid layout into docs landing pages

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,29 @@
 @import 'fumadocs-ui/style.css';
 
+/*
+ * Brand alignment with vaner.ai. Matches the amber accent + display
+ * type used on the marketing site / /developers bridge so the docs
+ * read as the same product.
+ */
+:root {
+  --vaner-amber: #e0a557;
+}
+
+/*
+ * Fumadocs <Card> grid: tighter than default, amber border + soft fill
+ * on hover, matching the .dev-card style on vaner.ai/developers.
+ */
+@layer components {
+  [data-card] {
+    transition: border-color 0.15s ease, transform 0.15s ease, background-color 0.15s ease;
+  }
+  [data-card]:hover {
+    border-color: color-mix(in oklch, var(--vaner-amber) 65%, var(--color-fd-border));
+    background-color: color-mix(in oklch, var(--vaner-amber) 4%, transparent);
+    transform: translateY(-1px);
+  }
+}
+
 @layer base {
   /*
    * Keep docs content centered at normal widths, but pin the sidebar to the

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -72,7 +72,9 @@ Vaner can discover active `SKILL.md` files and treat them as intent priors.
 Skill metadata contributes to feature extraction, seeds frontier candidates, and
 can bias ranking before prompt-time requests arrive.
 
-See [Agent Skills](/skills) for the full loop.
+See [Client capability matrix](/integrations/client-capabilities) for
+the per-client skill / workflow / prompt support and how Vaner's
+`vaner-feedback` adapter fits in.
 
 ### MCP runtime (model pull)
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -15,22 +15,44 @@ will not apply it or edit your files unless you explicitly export or adopt it.
 
 ## Install Vaner
 
-**[→ Download Vaner Desktop](https://vaner.ai)** — recommended for everyone.
-The desktop app starts the engine, picks a local model that fits your
-hardware, and wires Vaner into the AI clients it detects on your machine
-(Claude Code, Cursor, Zed, VS Code, Claude Desktop, …). No command line
-required.
-
-**[→ Install the CLI](/getting-started)** — for power users, CI, and Docker.
-One-line installer for Linux/macOS, plus `pipx` / `uv` paths. Runs the same
-engine the desktop app uses.
+<Cards>
+  <Card
+    href="https://vaner.ai"
+    external
+    title="Download Vaner Desktop"
+    description="Recommended for everyone. The desktop app starts the engine, picks a local model that fits your hardware, and wires Vaner into the AI clients it detects on your machine (Claude Code, Cursor, Zed, VS Code, Claude Desktop, …). No command line required."
+  />
+  <Card
+    href="/getting-started"
+    title="Install the CLI"
+    description="For power users, CI, and Docker. One-line installer for Linux/macOS, plus pipx / uv paths. Runs the same engine the desktop app uses."
+  />
+</Cards>
 
 ## What's next
 
-- **[First-run setup](/simple-mode)** — what happens after you open the app for the first time
-- **[Prepared Work](/prepared-work)** — the main product surface, with examples
-- **[Connect your AI client](/integrations)** — wire Vaner into Claude Code, Cursor, Zed, and 7 other clients
-- **[Cockpit](/cockpit)** — live pipeline view, prepared work feed, goals, predictions
+<Cards>
+  <Card
+    href="/simple-mode"
+    title="First-run setup"
+    description="What happens after you open the app for the first time."
+  />
+  <Card
+    href="/prepared-work"
+    title="Prepared Work"
+    description="The main product surface, with examples."
+  />
+  <Card
+    href="/integrations/connect-your-client"
+    title="Connect your AI client"
+    description="Wire Vaner into Claude Code, Cursor, Zed, and 7 other clients."
+  />
+  <Card
+    href="/cockpit"
+    title="Cockpit"
+    description="Live pipeline view, prepared work feed, goals, predictions."
+  />
+</Cards>
 
 ## Why Vaner
 

--- a/content/docs/integrations/index.mdx
+++ b/content/docs/integrations/index.mdx
@@ -8,14 +8,47 @@ This section covers integration modes and tool-specific recipes.
 
 ## Default integration (recommended)
 
-- [MCP mode](/integrations/mcp): native IDE/agent integration where models pull prepared scenarios via tools.
-- [Tool-specific pages](/integrations/connect-your-client): copy/paste setup and verification by client.
+<Cards>
+  <Card
+    href="/integrations/connect-your-client"
+    title="Connect your AI client"
+    description="One command per client (Claude Code, Cursor, Codex CLI, Cline, Continue, Zed, Windsurf, Roo, VS Code, Claude Desktop). Manual-setup picker if you'd rather paste it yourself."
+  />
+  <Card
+    href="/integrations/mcp"
+    title="MCP mode"
+    description="Conceptual overview: how Vaner exposes Prepared Work and the vaner.* tool family to MCP-aware clients."
+  />
+  <Card
+    href="/integrations/client-capabilities"
+    title="Client capability matrix"
+    description="Per-client support for the four leverage layers — MCP, primer, skill, hooks."
+  />
+</Cards>
 
 ## Advanced and compatibility modes
 
-- [Context-only mode](/integrations/context-only): call `/v1/context` directly from custom frameworks.
-- [Python SDK mode](/integrations/python-sdk): use Vaner as a library inside scripts and automation.
-- [Proxy mode](/integrations/proxy): OpenAI-compatible `/v1/chat/completions` for clients that cannot use MCP.
-- [Docker](/integrations/docker): compose topology for local multi-service setups.
+<Cards>
+  <Card
+    href="/integrations/context-only"
+    title="Context-only mode"
+    description="Call /v1/context directly from custom frameworks."
+  />
+  <Card
+    href="/integrations/python-sdk"
+    title="Python SDK"
+    description="Use Vaner as a library inside scripts and automation."
+  />
+  <Card
+    href="/integrations/proxy"
+    title="Proxy mode"
+    description="OpenAI-compatible /v1/chat/completions for clients that cannot use MCP."
+  />
+  <Card
+    href="/integrations/docker"
+    title="Docker"
+    description="Compose topology for local multi-service setups."
+  />
+</Cards>
 
 If your client supports MCP, prefer MCP mode first and only use advanced modes when needed.

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,4 +1,5 @@
 import defaultMdxComponents from 'fumadocs-ui/mdx';
+import { Card, Cards } from 'fumadocs-ui/components/card';
 import type { MDXComponents } from 'mdx/types';
 import { McpClientPickerServer } from '@/components/mcp/client-picker-server';
 import { BackendPresetPickerServer } from '@/components/mcp/backend-picker-server';
@@ -7,6 +8,8 @@ import { ComputeBudget } from '@/components/mcp/compute-budget';
 export function useMDXComponents(components: MDXComponents): MDXComponents {
   return {
     ...defaultMdxComponents,
+    Card,
+    Cards,
     McpClientPicker: McpClientPickerServer,
     BackendPresetPicker: BackendPresetPickerServer,
     ComputeBudget,


### PR DESCRIPTION
## Summary
- Brings the bridge styling from vaner.ai/developers into docs.vaner.ai so the two surfaces read as the same product.
- Docs root and integrations index become Fumadocs `<Cards>`/`<Card>` grids instead of bullet lists.
- Adds an amber-accent hover treatment on `[data-card]` matching the bridge `.dev-card` style. No new component system; just promotes existing Fumadocs primitives.

## Files changed
- `mdx-components.tsx` — re-export `Card` + `Cards` from `fumadocs-ui/components/card` so MDX can use them unscoped.
- `app/globals.css` — `[data-card]:hover` amber border + soft fill.
- `content/docs/index.mdx` — Install / What's next sections → card grids.
- `content/docs/integrations/index.mdx` — Default / Advanced sections → card grids.

## Test plan
- [x] `npm run build` clean
- [ ] CI: lychee + build + changelog-sync green
- [ ] Visual check on prod after deploy