### PR TITLE
docs: drop single-page section headers + pin sidebar to left edge

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -90,12 +90,16 @@ em {
 
 @layer base {
   /*
-   * Wide-screen layout — sidebar pinned to viewport edge.
+   * Sidebar pinned to the LEFT edge at all widths above the
+   * mobile breakpoint, matching docs.ollama.com. Fumadocs' default
+   * centers the whole layout inside 1400px, which floats the sidebar
+   * away from the viewport edge — wrong for a docs site.
+   *
+   * Grid: [sidebar flush left] [content] [optional toc] [spacer].
    */
-  @media (min-width: 1800px) {
+  @media (min-width: 1024px) {
     #nd-docs-layout {
       grid-template-columns:
-        0
         var(--fd-sidebar-col)
         minmax(0, calc(var(--fd-layout-width, 97rem) - var(--fd-sidebar-width) - var(--fd-toc-width)))
         var(--fd-toc-width)

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -2,11 +2,8 @@
   "title": "Vaner",
   "pages": [
     "index",
-    "---Get started---",
     "getting-started",
-    "---What it does---",
     "prepared-work",
-    "---Integrations---",
     "integrations",
     "---Reference---",
     "cli",


### PR DESCRIPTION
Two sidebar layout fixes:

### Single-page section headers gone
`---Get started---` above a single 'Getting started' page (and the same for 'What it does' / 'Integrations') was redundant. Pages float at the top of the sidebar without labels. `Reference` (9 pages) and `More` (2 pages) keep theirs.

### Sidebar pinned to the left edge
Fumadocs centered the whole layout inside `--fd-layout-width` (1400px), floating the sidebar away from the viewport edge — visible everywhere except on very wide screens. Sidebar is now flush-left at `>=1024px`, matching `docs.ollama.com`.

## Test plan
- [x] `npm run build` clean
- [ ] CI green
- [ ] Visual check after deploy: sidebar at left edge, no redundant section headers