### PR TITLE
docs: drop deep-tech pages from sidebar + simpler architecture

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -1,115 +1,63 @@
 ---
 title: Architecture
-description: How Vaner runs beside your model and serves Prepared Work over MCP and HTTP.
+description: How Vaner runs beside your AI client.
 ---
 
-Vaner is built around one default architecture:
+Vaner runs as a small daemon next to your editor. It watches your repo,
+prepares work in the background, and serves that work to your AI client
+through MCP when you ask. The model never waits on Vaner — Vaner has the
+answer ready.
 
-- **MCP-first model interface:** your client calls tools; Vaner is not the chat
-  completion hot path.
-- **Side-running ponder engine:** Vaner precomputes likely useful work in the
-  background.
-- **Prepared Work surface:** clients see a small, action-oriented feed instead
-  of raw prediction/work-product lifecycle state.
-- **Local cockpit controls:** operators inspect, debug, and tune behavior.
+## What you see
 
-## Two loops: precompute and serve
+- **Your AI client.** Cursor, Claude Code, Codex, Zed, etc. Calls Vaner
+  through MCP tools (`vaner.resolve`, `vaner.prepared_work.dashboard`, …)
+  to pull prepared work.
+- **The cockpit.** A local web UI at `http://127.0.0.1:8473` (started
+  with `vaner up`). Shows what Vaner has prepared, why, and what's
+  in flight. See [Prepared Work](/prepared-work#inspecting-prepared-work).
+- **The desktop app** (optional). A menu-bar / tray shell that wraps
+  the daemon, surfaces the most-recent prepared moment, and adopts
+  drafts into your active client with one click.
 
-- **Ponder loop (background):** watches repo signals, expands frontier
-  candidates, and refreshes scenarios, artifacts, predictions, and work
-  products in storage.
-- **Answer loop (prompt-time):** serves Prepared Work or precomputed context over
-  MCP/HTTP when your client asks during a real task.
+All three talk to the same daemon. None of them are in the model's hot
+path — they pull from a queue Vaner keeps populated.
 
-This split is the core performance model: expensive exploration happens between
-prompts, while prompt-time retrieval stays fast and deterministic.
-
-## Runtime flow
+## What Vaner does
 
 ```mermaid
 flowchart LR
-  Repo[RepoSignals] --> Intent[IntentLayer]
-  Skills[SkillDiscovery] --> Intent
-  Intent --> Frontier[ExplorationFrontier]
-  Frontier --> Builder[ScenarioBuilder]
-  Builder --> Store[ScenarioStore]
-  Store --> Prepared[PreparedWork]
-  Prepared --> MCP[MCPServer]
-  MCP --> Agent[IDEOrAgent]
-  Agent -->|feedback| MCP
-  MCP --> Feedback[FeedbackQueue]
-  Feedback --> Frontier
-  Store --> Cockpit[CockpitHTTPAndCLI]
+  Repo[Repo signals] --> Vaner[Vaner daemon]
+  Vaner --> Store[Prepared work + evidence]
+  Store --> MCP[MCP tools]
+  MCP --> Agent[Your AI client]
+  Agent -->|feedback| Vaner
 ```
 
-## Core components and boundaries
+When the repo changes (a commit lands, a file changes, a test runs),
+Vaner notices and **prepares**. Preparing means: pulling related context,
+running the model in idle time, scoring multiple candidate angles, and
+landing the strongest as a Prepared Work card with evidence attached.
 
-### Ponder loop and scenario builder
+When you actually ask the agent something, Vaner has the relevant card
+ready to hand over instead of starting from a cold retrieval pass.
 
-The daemon watches repo activity, produces artefacts, and continuously expands
-ranked scenarios into `scenarios.db`. This is where depth, frontier size,
-deduplication, and compute limits are enforced.
+## Boundaries
 
-### Scenario store and scoring
+- **Non-mutating by default.** Vaner can prepare a virtual diff but
+  never applies it. Adopt is an explicit user action.
+- **Local-first.** The daemon, the cockpit, and the model all run on
+  your machine unless you've chosen a hybrid bundle. Privacy posture
+  is part of the [policy bundle](/policy-bundles) you pick at install.
+- **Read-only against your code.** Vaner reads the working tree and
+  git history; it doesn't write to your branch.
 
-Each scenario stores prepared context, evidence references, freshness, expansion
-cost, and outcomes. Vaner re-scores scenarios so clients can pick promising
-candidates quickly via MCP tools.
+## Going deeper
 
-### Prepared Work layer
+The internal moving parts (frontier exploration, scenario scoring,
+prediction registry, refinement context) aren't user-facing. If you
+want them, the source is the canonical reference: see
+[`src/vaner/engine.py`](https://github.com/Borgels/vaner/blob/main/src/vaner/engine.py)
+and the per-component modules under `src/vaner/`.
 
-Prepared Work is the product-facing layer above predictions and work products.
-It filters hidden/stale/dismissed/superseded items, ranks by usefulness,
-confidence, freshness, evidence, and actionability, and returns UI-safe cards
-with only server-authorized actions.
-
-Virtual diffs live in Vaner-owned storage. They can be inspected and exported,
-but Vaner does not automatically mutate the user's worktree.
-
-### Agent skills prior
-
-Vaner can discover active `SKILL.md` files and treat them as intent priors.
-Skill metadata contributes to feature extraction, seeds frontier candidates, and
-can bias ranking before prompt-time requests arrive.
-
-See [Client capability matrix](/integrations/client-capabilities) for
-the per-client skill / workflow / prompt support and how Vaner's
-`vaner-feedback` adapter fits in.
-
-### MCP runtime (model pull)
-
-MCP tools expose Prepared Work, query resolution, scenario navigation,
-workspace goals, setup/policy controls, and Deep-Run sessions. Feedback closes
-the loop by feeding usefulness signals back into future ranking.
-
-### Cockpit runtime (human controls)
-
-Cockpit endpoints and CLI commands expose status, freshness distribution, device
-configuration, and live scenario stream updates. See
-[Prepared Work](/prepared-work#inspecting-prepared-work) for the operator view.
-
-### Optional gateway capability
-
-`vaner proxy` remains available for clients that only support OpenAI-compatible
-endpoints. It is a legacy compatibility layer, not the default integration
-path; prefer MCP-first wiring whenever your client supports MCP.
-
-## Vocabulary
-
-- **Signal**: observed event from filesystem or git state.
-- **Scenario**: candidate context branch with ranked files, evidence, and expansion metadata.
-- **Frontier**: priority queue of scenarios waiting for deeper exploration.
-- **Artefact**: precomputed context unit (summary, index, diff).
-- **Prepared Work**: user-facing card Vaner prepared before the prompt, with evidence, freshness, confidence, and safe actions.
-- **Work Product**: internal stored artifact behind some Prepared Work cards.
-- **Virtual Diff**: patch-shaped Prepared Work; never auto-applied.
-- **Prediction**: internal next-intent candidate. Strong predictions surface as Prepared Work.
-- **Context Package**: selected and compressed artefacts for a prompt.
-- **Decision Record**: persisted explanation of why Vaner picked one package over alternatives.
-- **Policy**: privacy and token-budget rules.
-- **Agent Skill**: `SKILL.md` playbook metadata used as intent prior and feedback attribution signal.
-- **Ponder Loop**: idle-time branch exploration and artifact preparation.
-- **Answer Loop**: prompt-time ranking and assembly when a client asks.
-- **Goal**: long-horizon intent persisted across daemon restarts.
-- **Reconciliation**: when a repo signal lands, Vaner checks each goal's linked artefacts against the new state and updates status.
-- **Pinned Facts**: explicit user steering directives that bias preparation without prompt injection.
+For knob-by-knob configuration, see [Configuration](/configuration).

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -80,97 +80,24 @@ vaner config set gateway.routes.gpt- https://api.openai.com/v1 --path .
 vaner config edit --path .
 ```
 
-## Advanced knobs
-
-Most users get sensible defaults from the policy bundle picked at install
-time. The sections below are for custom backends, hybrid setups, and the
-prediction / Deep-Run dials.
-
-### Runtime and providers
-
-| Field | Purpose |
-|---|---|
-| `backend.local_runtime` | One of `ollama`, `llama.cpp`, `lmstudio`, `vllm`, `mlx`, `auto`. |
-| `backend.base_url` | OpenAI-compatible endpoint URL. |
-| `backend.model` | Model id served by `base_url`. |
-| `backend.api_key_env` | Env var holding the API key, if needed. |
-| `backend.cloud_provider` | Optional cloud provider id (`openai`, `anthropic`, …) for hybrid bundles. |
-| `backend.routing` | `local`, `cloud`, or `auto`. |
-
-Leave `local_runtime = "auto"` and let the hardware probe pick. Override
-`routing = "local"` to disable cloud calls without changing the cloud
-provider id.
-
-### Budgets
-
-| Field | Purpose |
-|---|---|
-| `compute.max_cycle_seconds` | Wall-clock cap per ponder cycle. Default 300s. |
-| `compute.max_session_minutes` | Total daemon session time. |
-| `compute.max_concurrent_jobs` | Parallel cycles. |
-| `budgets.daily_cost_cap` | Daily USD cap on cloud spend. |
-| `budgets.tokens.foreground` | User-facing answer cap. |
-| `budgets.tokens.background` | Idle pondering cap. |
-| `budgets.tokens.deep_run` | Explicit overnight session cap. |
-
-Set the dollar cap first, then dial cycle / job knobs to match the
-[hardware tier](/hardware-tiers).
-
-### Reasoning and drafting
-
-| Field | Purpose |
-|---|---|
-| `drafting.reasoning_mode` | `fast`, `balanced`, `deep`. |
-| `drafting.aggressiveness` | `0.7` cautious to `1.3` eager. |
-| `drafting.evidence_threshold` | Raw threshold (aggressiveness multiplies in). |
-| `drafting.contradiction_behavior` | `flag`, `defer`, `block`. |
-
-Bumping `aggressiveness` is the cheapest way to make Vaner *feel* faster,
-at the cost of more incomplete drafts.
-
-### Prediction policy
-
-| Field | Purpose |
-|---|---|
-| `prediction.horizon_bias` | Weights over `likely_next`, `long_horizon`, `finish_partials`, `balanced`. Normalised before applying. |
-| `prediction.exploration_ratio` | `-0.10` exploit to `+0.15` explore. |
-| `prediction.persistence_strength` | `0.6` decay-fast to `1.5` decay-slow. |
-| `prediction.goal_weighting` | `0.8` to `1.4`. Multiplier on goal-aligned scoring. |
-
-These four knobs interact strongly. Start from a bundle and nudge one
-axis at a time. Reference: [`catalog.py`](https://github.com/Borgels/vaner/blob/main/src/vaner/setup/catalog.py).
-
-### Deep-Run
-
-| Field | Purpose |
-|---|---|
-| `deep_run.preset` | `conservative`, `balanced`, `aggressive`. |
-| `deep_run.max_duration_minutes` | Hard cap per session. |
-| `deep_run.locality` | `local_only`, `hybrid`, `cloud_preferred`. Per-session override. |
-| `deep_run.cost_cap_usd` | Per-session cloud spend cap. |
-| `deep_run.focus` | Free-text focus hint passed to the planner. |
-| `deep_run.prefer` | Optional list of skills, scenarios, or work-styles to bias toward. |
-
-Defaults derive from the active bundle's `deep_run_profile`. Override
-per-session via the cockpit "Start Deep-Run" dialog or
-`GET /deep-run/defaults` for programmatic consumers.
-
-### Integration
-
-| Field | Purpose |
-|---|---|
-| `integration.guidance_injection` | `off`, `passive`, `active`. |
-| `integration.context_injection.mode` | `none`, `digest_only`, `adopted_package_only`, `top_match_auto_include`, `policy_hybrid`, `client_controlled`. |
-| `integration.mcp_apps_enabled` | Toggle the MCP Apps UI surface. |
-| `integration.handoff_method` | inline, attachment, resource link. |
-
-`policy_hybrid` is the right default for almost all bundles. Drop to
-`digest_only` when context windows are tight; use `client_controlled` when
-the IDE drives inclusion explicitly.
-
-## Where to set these
+## Where to set values
 
 - `.vaner/config.toml`. Persistent.
 - `vaner config set <key> <value>`. Hot-reloads the daemon.
 - `vaner config edit`. Opens the file in `$EDITOR`.
 - Cockpit Preferences → Engine. Interactive editor.
+
+## Advanced knobs
+
+Most users don't touch these. The policy bundle picked at install time
+already sets sensible values for every section.
+
+If you do need to tune something specific (custom backend URL, daily
+spend cap, prediction horizon bias, etc.), the full knob surface is in
+the source — see
+[`src/vaner/models/config.py`](https://github.com/Borgels/vaner/blob/main/src/vaner/models/config.py)
+for every field with its type and default. Or:
+
+```bash
+vaner config keys --path .   # list every settable key
+```

--- a/content/docs/integrations/meta.json
+++ b/content/docs/integrations/meta.json
@@ -3,9 +3,7 @@
   "pages": [
     "index",
     "connect-your-client",
-    "client-capabilities",
     "mcp",
-    "composer-adapter",
     "context-only",
     "python-sdk",
     "proxy",

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -10,8 +10,6 @@
     "configuration",
     "backends",
     "supported-hardware",
-    "policy-bundles",
-    "hardware-tiers",
     "architecture",
     "security",
     "changelog",


### PR DESCRIPTION
## Summary
Per user feedback that some pages were too engineer-internal:

### Pages dropped from sidebar (files stay on disk)
- `integrations/composer-adapter` — internal product spec.
- `integrations/client-capabilities` — useful but reads as engineer-internal.
- `hardware-tiers` — raw config tables; bundle picker handles this.
- `policy-bundles` — 7 × 12 dimension matrix; way too much for sidebar.

Cross-references in other pages still work (files render, lychee passes).

### `architecture.mdx` rewritten
Was 100 lines of internal vocab (ponder loop / frontier / scenario builder / …). Now ~50 lines about what users actually see (AI client, cockpit, optional desktop app), what the data flow looks like at user-visible granularity, and the behavioral boundaries (non-mutating, local-first, read-only). Source is linked for the engineer-internal parts.

### `configuration.mdx` trimmed
Six-section knob reference replaced with a pointer to `src/vaner/models/config.py` and `vaner config keys`. Most users never touch any of these; the policy bundle covers it.

## Test plan
- [x] `npm run build` clean
- [ ] CI green (lychee, build, changelog-sync)
- [ ] Visual: sidebar shorter, cross-references still resolve