### PR TITLE
docs: add Auto Focus guide

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -31,6 +31,7 @@ jobs:
             --exclude '^https://docs\.vaner\.ai/hardware-tiers($|#)'
             --exclude '^https://docs\.vaner\.ai/deep-run($|#)'
             --exclude '^https://docs\.vaner\.ai/prepared-work($|#)'
+            --exclude '^https://docs\.vaner\.ai/auto-focus($|#)'
             --exclude '^https://docs\.vaner\.ai/human-product-proof($|#)'
             --exclude https://docs.vaner.ai/integrations/integration-layer
             "./**/*.md"

--- a/content/docs/auto-focus.mdx
+++ b/content/docs/auto-focus.mdx
@@ -1,0 +1,101 @@
+---
+title: Auto Focus
+description: How Vaner decides whether to work, where to work, and why.
+---
+
+Auto Focus is Vaner's daemon-owned focus layer. It keeps Vaner quiet when
+there is no useful workspace context and allows Prepared Work only when one
+eligible workspace is clearly selected.
+
+The desktop apps are control surfaces. They show daemon state and send user
+actions, but they do not decide the active workspace or scheduling policy.
+
+## Default behavior
+
+- No supported client running: Vaner is idle except cheap maintenance.
+- Supported client running, no wired workspace: Vaner stays in standby.
+- One wired active workspace: Vaner may prepare work for that workspace.
+- Multiple workspaces: Vaner chooses one only when confidence is high.
+- Ambiguity: Vaner stays in standby instead of guessing.
+- Paused workspace: no repo reads, indexing, reasoning, or Prepared Work.
+
+Vaner selects at most one proactive workspace by default. Other workspaces are
+standby, dormant, unknown, or paused.
+
+## Privacy boundary
+
+Vaner can detect supported AI clients so it knows when to stay quiet and when
+to prepare work. It only checks supported clients and Vaner integrations. It
+does not read prompts, window titles, browser tabs, clipboard, terminal
+history, terminal buffers, or arbitrary apps.
+
+Client detection is local and default-enabled. You can switch to Manual Only
+or Pause Vaner from Desktop, CLI, or MCP.
+
+## Why not working
+
+Auto Focus exposes skipped and deferred reasons everywhere:
+
+- Desktop Focus panel
+- `vaner focus status`
+- `vaner.focus.status`
+- `GET /focus`
+
+Example:
+
+```text
+Standby: Cursor is running, but no wired workspace was detected.
+Action: Connect this workspace or choose Work Here.
+```
+
+## CLI
+
+```bash
+vaner focus status
+vaner focus work-here .
+vaner focus pin .
+vaner focus pause .
+vaner focus resume .
+vaner focus pause --all
+vaner focus mode manual-only
+vaner resources status
+vaner jobs status
+```
+
+## MCP tools
+
+```text
+vaner.focus.status
+vaner.focus.work_here
+vaner.focus.pin_current_workspace
+vaner.focus.pause_current_workspace
+vaner.focus.resume_current_workspace
+vaner.focus.set_mode
+vaner.resources.status
+vaner.jobs.status
+vaner.jobs.cancel
+```
+
+## HTTP
+
+```text
+GET  /focus
+POST /focus/workspaces/{id}/work-here
+POST /focus/workspaces/{id}/pin
+POST /focus/workspaces/{id}/unpin
+POST /focus/workspaces/{id}/pause
+POST /focus/workspaces/{id}/resume
+POST /focus/pause-all
+POST /focus/mode
+GET  /resources
+GET  /jobs
+```
+
+`/resources` is read-only in this release. It exposes minimal local runtime
+and device inventory from existing Vaner config and hardware probes.
+
+## Cloud execution
+
+Auto Focus does not run proactive or background work in the cloud in this
+release. Future cloud execution, if added, will be explicit policy rather than
+silent fallback.

--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -9,6 +9,30 @@ Notable product releases are published on [**GitHub Releases**](https://github.c
 
 _The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog -- --force`._
 
+## v0.8.10
+
+_Released May 2, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.10)_
+
+- chore: harden release preflight discipline
+- ci: harden zizmor workflow checks
+- feat: productize Prepared Work surface
+- chore(readme): simplify to ~100 lines, single front-door, link to docs
+- feat(primer): add Zed, Windsurf, Roo Code primer surfaces
+- feat(clients): add `vaner clients verify` for the four-layer leverage stack
+- ...and more on [GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.10).
+
+## v0.8.9
+
+_Released May 2, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.9)_
+
+- fix(setup): pick qwen3.6 (latest+best) for 32 GB cards instead of qwen3.5 (#224) @abolsen
+- feat: cockpit refresh + model catalog refresher with proper sampling defaults (#211) @abolsen
+- feat(cli): vaner up --json + per-device GPU enumeration (#221) @abolsen
+- feat(init): auto-apply policy bundle, no five-question wizard (#220) @abolsen
+- feat(cli): `vaner launch <client>` end-to-end installer (#218) @abolsen
+- feat(hooks): Cline + Windsurf prompt-submit hooks (Phase C4) (#217) @abolsen
+- ...and more on [GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.9).
+
 ## Vaner 0.8.8
 
 _Released April 30, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.8)_

--- a/content/docs/meta.json
+++ b/content/docs/meta.json
@@ -4,6 +4,7 @@
     "index",
     "getting-started",
     "prepared-work",
+    "auto-focus",
     "integrations",
     "---Reference---",
     "cli",

--- a/content/docs/prepared-work.mdx
+++ b/content/docs/prepared-work.mdx
@@ -15,6 +15,10 @@ you ask. Each card answers four questions:
 Vaner intentionally shows few, strong items. Candidate, hidden, stale, and
 superseded artefacts stay out of the feed.
 
+Auto Focus gates this feed. By default, proactive Prepared Work only runs for
+one eligible active workspace; ambiguous or paused workspaces stay quiet. See
+[Auto Focus](/auto-focus).
+
 ## What can appear
 
 - Review notes


### PR DESCRIPTION
## Summary
- adds Auto Focus documentation
- links Prepared Work docs to the Auto Focus scheduling gate
- adds the page to docs navigation

## Tests
- npm run build

Commits are unsigned by request.