### PR TITLE
docs(release): add v0.9.0 changelog note

### DIFF
--- a/content/docs/changelog.mdx
+++ b/content/docs/changelog.mdx
@@ -9,6 +9,15 @@ Notable product releases are published on [**GitHub Releases**](https://github.c
 
 _The section below is generated from [GitHub Releases](https://github.com/Borgels/vaner/releases). Edit release notes on GitHub, then run `npm run sync:changelog -- --force`._
 
+## v0.9.0
+
+_Released May 4, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.9.0)_
+
+- Auto Focus surfaces prepared work closer to the moment of use, with tighter linting around promoted, archived, and contradictory memory
+- `vaner launch <client>` and `vaner clients verify` make setup and recovery easier across supported AI clients
+- Setup now applies policy bundles automatically and improves local model/GPU selection for desktop-class machines
+- Signed PyPI artifacts, SBOM, and provenance are attached to the GitHub release
+
 ## v0.8.10
 
 _Released May 2, 2026 · [Details on GitHub](https://github.com/Borgels/vaner/releases/tag/v0.8.10)_

--- a/package-lock.json
+++ b/package-lock.json
@@ -4450,9 +4450,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4469,9 +4469,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "typescript": "^6"
+  },
+  "overrides": {
+    "postcss": "8.5.10"
   }
 }


### PR DESCRIPTION
## Summary
- add a concise v0.9.0 changelog entry from the tightened GitHub release notes
- add the existing PostCSS security override pattern to clear the moderate audit finding

## Verification
- `npm ci`
- `npm run sync:changelog -- --force`
- `npm audit --audit-level=moderate`
- `npm run build`