### PR TITLE
docs: add macOS desktop guidance

### DIFF
--- a/content/docs/backends.mdx
+++ b/content/docs/backends.mdx
@@ -9,14 +9,29 @@ precompute).
 
 ## Default backend (most users)
 
-Set one backend in `~/.vaner/config.toml`:
+Vaner Desktop and `vaner init` default to Ollama on localhost. That is the
+same default on macOS, Windows, and Linux.
+
+The generated local config looks like this:
 
 ```toml
 [backend]
+name = "ollama"
 base_url = "http://127.0.0.1:11434/v1"
-model = "qwen2.5-coder:32b"
-api_key_env = "OLLAMA_API_KEY"
+model = "llama3.2:3b"
+api_key_env = ""
+prefer_local = true
+```
 
+You can switch to a larger pulled Ollama model later:
+
+```bash
+vaner config set backend.model qwen3.5:8b --path .
+```
+
+Hosted backends are explicit alternatives:
+
+```toml
 [backends.openai]
 base_url = "https://api.openai.com/v1"
 model = "gpt-4o"
@@ -28,8 +43,8 @@ model = "claude-sonnet-4-20250514"
 api_key_env = "ANTHROPIC_API_KEY"
 ```
 
-Use this with MCP mode (`vaner mcp --path .`): your client calls Vaner tools and
-Vaner ponders with the configured backend.
+Use this with MCP mode (`vaner mcp --path .`): your client calls Vaner tools
+and Vaner ponders with the configured backend.
 
 ## Picking local vs hosted
 

--- a/content/docs/configuration.mdx
+++ b/content/docs/configuration.mdx
@@ -9,9 +9,11 @@ Vaner reads configuration from `.vaner/config.toml`.
 
 ```toml
 [backend]
+name = "ollama"
 base_url = "http://127.0.0.1:11434/v1"
-model = "qwen2.5-coder:32b"
-api_key_env = "OLLAMA_API_KEY"
+model = "llama3.2:3b"
+api_key_env = ""
+prefer_local = true
 
 [mcp]
 transport = "stdio"

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -4,12 +4,28 @@ description: Install Vaner, answer five questions, start the daemon.
 ---
 
 The fastest path is the [Vaner Desktop app](https://vaner.ai). It installs the
-engine, picks a local model that fits your hardware, and wires Vaner into the
-AI clients it detects. No CLI required.
+engine, picks a local Ollama model that fits your hardware, and wires Vaner
+into the AI clients it detects. No CLI required.
+
+macOS, Windows, and Linux are the same Vaner Desktop product. The macOS app
+does not have a separate feature set today; it is a native shell around the
+same Vaner engine, MCP wiring, and Ollama-first runtime.
 
 The CLI path below is for power users, CI, and Docker.
 
-## 1. Install
+## 1. Install Vaner Desktop
+
+macOS:
+
+1. Download the macOS DMG from the
+   [Vaner Desktop release](https://github.com/Borgels/vaner-desktop/releases/latest).
+2. Open the `.dmg` and drag Vaner into Applications.
+3. Launch Vaner Desktop and let it install/start Ollama if needed.
+
+If macOS blocks the first launch for an unsigned 0.x build, right-click
+Vaner and choose **Open** once.
+
+## 2. CLI install
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
@@ -36,7 +52,7 @@ curl -fsSL https://vaner.ai/install.sh | bash
 
 Full env-var list and source: [scripts/install.sh](https://github.com/Borgels/vaner/blob/main/scripts/install.sh).
 
-## 2. Initialize
+## 3. Initialize
 
 ```bash
 vaner init --path .
@@ -49,7 +65,7 @@ your machine. You confirm the client list before anything is written.
 If you want to override the auto-picked bundle, run
 `vaner setup apply <bundle-id>` after init.
 
-## 3. Start
+## 4. Start
 
 ```bash
 vaner up --path .

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -21,7 +21,7 @@ adopt it.
     href="https://vaner.ai"
     external
     title="Download Vaner Desktop"
-    description="Recommended for everyone. Starts the engine, picks a local model that fits your hardware, and wires Vaner into your AI clients. No command line required."
+    description="Recommended for everyone on macOS, Windows, and Linux. Starts the engine, picks a local Ollama model that fits your hardware, and wires Vaner into your AI clients."
   />
   <Card
     href="/getting-started"
@@ -63,5 +63,6 @@ Vaner is successful when it improves at least one of:
 - **Prompt-time latency.** Work is prepared in advance; the agent picks it up when you ask.
 - **Cost per good answer.** Local idle compute substitutes for cloud round-trips on routine paths.
 
-Model-agnostic. Local Ollama, vLLM, llama.cpp, MLX, or cloud (OpenAI,
-Anthropic, OpenRouter) all work the same way through MCP.
+Model-agnostic. Local Ollama is the default runtime, including on Apple
+Silicon Macs. vLLM, llama.cpp-compatible servers, or cloud backends
+(OpenAI, Anthropic, OpenRouter) also work through the same MCP surface.

--- a/content/docs/supported-hardware.mdx
+++ b/content/docs/supported-hardware.mdx
@@ -7,6 +7,11 @@ Vaner uses [Ollama](https://ollama.com) as its default local runtime,
 so **Vaner runs everywhere Ollama runs**. If your machine can pull and
 run a model with `ollama run`, Vaner can use it.
 
+On macOS, Ollama officially supports
+[macOS Sonoma v14+](https://docs.ollama.com/macos) and Apple M-series
+CPUs/GPUs. Apple GPU acceleration uses
+[Metal](https://docs.ollama.com/gpu); Intel Macs run Ollama CPU-only.
+
 The defaults the Vaner Desktop app picks are tuned to fit comfortably
 on the hardware it detects. You can override the model later via
 `vaner config set backend.model <id>`.
@@ -48,9 +53,9 @@ treat as best-effort.
 
 ## Apple Silicon
 
-M1 and later are fully supported via Metal. Unified memory is the
-constraint, the model has to fit in shared system RAM, with headroom
-for macOS itself.
+M1 and later are the recommended Mac path. Ollama uses Metal for Apple GPU
+acceleration. Unified memory is the constraint: the model has to fit in
+shared system RAM, with headroom for macOS itself.
 
 | Unified memory | Practical model size |
 |---|---|
@@ -87,15 +92,15 @@ preset = "background"
 | OS | Status |
 |---|---|
 | Linux (Ubuntu, Fedora, Debian, Arch) | Supported. Wayland and X11 both work — there's no Vaner-side difference. |
-| macOS 13+ | Supported (Apple Silicon native, Intel via Rosetta — Apple Silicon recommended). |
+| macOS 14+ | Supported with Ollama as the default runtime. Apple Silicon recommended; Intel Mac is CPU-only. |
 | Windows 10/11 | Supported via the [Vaner Desktop installer](https://vaner.ai). |
 
 ## What if my GPU isn't on Ollama's list?
 
 Two paths:
 
-1. **Run Vaner on a different machine.** The daemon is remote-friendly
-  , `vaner up` on a beefy box, point your AI client at its
+1. **Run Vaner on a different machine.** The daemon is remote-friendly:
+   `vaner up` on a beefy box, point your AI client at its
    loopback URL via SSH tunnel, done. See
    [Backends](/backends) for the configuration.
 2. **Use a cloud backend.** OpenAI / Anthropic / OpenRouter all work

--- a/content/docs/troubleshooting.mdx
+++ b/content/docs/troubleshooting.mdx
@@ -126,6 +126,11 @@ Confirm your configured model matches a pulled model in Ollama:
 - `.vaner/config.toml` -> `[backend].model`
 - `http://127.0.0.1:11434/api/tags` -> includes the same model name
 
+On macOS, install Ollama from [ollama.com/download](https://ollama.com/download)
+or let Vaner Desktop offer to install it. Apple Silicon Macs use Ollama's
+Metal acceleration automatically; Intel Macs are CPU-only, so use a smaller
+model if first-run checks are slow.
+
 ## CLI says daemon is stopped but doctor is green
 
 `vaner status` and `vaner doctor` now use the same runtime snapshot source. If they disagree, restart with:


### PR DESCRIPTION
## Summary
- Document macOS as part of the canonical Vaner Desktop product
- Keep Ollama as the default runtime across macOS, Windows, and Linux
- Add brief macOS hardware and troubleshooting notes

## Tests
- npm run build
- npm audit --audit-level=moderate