### PR TITLE
docs: clarify Vaner interaction surfaces

### DIFF
--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -5,23 +5,30 @@ description: How Vaner runs beside your AI client.
 
 Vaner runs as a small daemon next to your editor. It watches your repo,
 prepares work in the background, and serves that work to your AI client
-through MCP when you ask. The model never waits on Vaner — Vaner has the
+through MCP when you ask. The model never waits on Vaner; Vaner has the
 answer ready.
 
-## What you see
+## How you interact with Vaner
 
-- **Your AI client.** Cursor, Claude Code, Codex, Zed, etc. Calls Vaner
-  through MCP tools (`vaner.resolve`, `vaner.prepared_work.dashboard`, …)
-  to pull prepared work.
-- **The cockpit.** A local web UI at `http://127.0.0.1:8473` (started
-  with `vaner up`). Shows what Vaner has prepared, why, and what's
-  in flight. See [Prepared Work](/prepared-work#inspecting-prepared-work).
-- **The desktop app** (optional). A menu-bar / tray shell that wraps
-  the daemon, surfaces the most-recent prepared moment, and adopts
-  drafts into your active client with one click.
+Vaner is one local engine with several surfaces around it. MCP is the primary
+interface for AI agents. Desktop and Companion are the primary human controls.
 
-All three talk to the same daemon. None of them are in the model's hot
-path — they pull from a queue Vaner keeps populated.
+| Surface | Primary user | Purpose | Default? | Where documented |
+|---|---|---|---|---|
+| AI client via MCP | AI agent | Pull Prepared Work and call `vaner.*` tools from Cursor, Claude Code, Codex, Zed, and similar clients. | Yes, for agents | [MCP mode](/integrations/mcp) |
+| Desktop tray/taskbar window | Human user | Install, start/stop Vaner, see current status, and wire detected clients. | Yes, for humans | [Getting Started](/getting-started) |
+| Companion/settings thin client | Human user | Manage common settings, integrations, backend/runtime choices, and privacy posture. | Yes, through Desktop | [Configuration](/configuration) |
+| Cockpit / Web UI | Advanced user | Inspect engine state, priorities, Prepared Work, diagnostics, and live activity. | No, advanced | [Prepared Work](/prepared-work#inspecting-prepared-work) |
+| CLI | Power users / CI | Script setup, daemon control, status, doctor, logs, and config. | No | [CLI reference](/cli) |
+| Primer/rules, skills, plugins/hooks | AI agent integration | Make MCP usage reliable and client-specific by teaching clients when and how to use Vaner. | Yes, where supported | [Client integration depth](/integrations/client-capabilities) |
+| Proxy/gateway | Compatibility users | OpenAI-compatible fallback for tools that cannot call MCP directly. | No | [Proxy mode](/integrations/proxy) |
+
+Users normally do not install Vaner inside the AI client first. Vaner Desktop
+or `vaner init` configures the integration; the AI client is where the agent
+uses Vaner through MCP.
+
+All surfaces talk to the same daemon. None of them are in the model's hot path;
+they pull from a queue Vaner keeps populated.
 
 ## What Vaner does
 

--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install Vaner, answer five questions, start the daemon.
+description: Install Vaner Desktop, connect your AI client, and start using Prepared Work.
 ---
 
 The fastest path is the [Vaner Desktop app](https://vaner.ai). It installs the
@@ -11,21 +11,35 @@ macOS, Windows, and Linux are the same Vaner Desktop product. The macOS app
 does not have a separate feature set today; it is a native shell around the
 same Vaner engine, MCP wiring, and Ollama-first runtime.
 
-The CLI path below is for power users, CI, and Docker.
+You normally do not install Vaner inside the AI client first. Desktop configures
+the integration, then your AI client uses Vaner through MCP.
 
-## 1. Install Vaner Desktop
+## How you interact with Vaner
+
+| Surface | Primary user | Purpose | Default? | Where documented |
+|---|---|---|---|---|
+| AI client via MCP | AI agent | Pull Prepared Work and call `vaner.*` tools during a task. | Yes, for agents | [MCP mode](/integrations/mcp) |
+| Desktop tray/taskbar window | Human user | Install, start/stop Vaner, see status, and wire detected clients. | Yes, for humans | [Install Vaner Desktop](#install-vaner-desktop) |
+| Companion/settings thin client | Human user | Manage common settings, integrations, backend/runtime choices, and privacy posture. | Yes, through Desktop | [Configuration](/configuration) |
+| Cockpit / Web UI | Advanced user | Inspect engine state, priorities, Prepared Work, diagnostics, and live activity. | No, advanced | [Prepared Work](/prepared-work#inspecting-prepared-work) |
+| CLI | Power users / CI | Script setup, daemon control, status, doctor, logs, and config. | No | [Power users / CI](#power-users--ci) |
+| Primer/rules, skills, plugins/hooks | AI agent integration | Make MCP usage reliable and client-specific. | Yes, where supported | [Client integration depth](/integrations/client-capabilities) |
+| Proxy/gateway | Compatibility users | OpenAI-compatible fallback for tools that cannot call MCP directly. | No | [Proxy mode](/integrations/proxy) |
+
+## Install Vaner Desktop
 
 macOS:
 
-1. Download the macOS DMG from the
-   [Vaner Desktop release](https://github.com/Borgels/vaner-desktop/releases/latest).
+1. Download [Vaner Desktop for macOS](https://vaner.ai/download/macos).
 2. Open the `.dmg` and drag Vaner into Applications.
 3. Launch Vaner Desktop and let it install/start Ollama if needed.
 
 If macOS blocks the first launch for an unsigned 0.x build, right-click
 Vaner and choose **Open** once.
 
-## 2. CLI install
+## Power users / CI
+
+Use the CLI path for CI, Docker, SSH-only machines, or scripted setup.
 
 ```bash
 curl -fsSL --proto '=https' --tlsv1.2 https://vaner.ai/install.sh | bash
@@ -52,7 +66,7 @@ curl -fsSL https://vaner.ai/install.sh | bash
 
 Full env-var list and source: [scripts/install.sh](https://github.com/Borgels/vaner/blob/main/scripts/install.sh).
 
-## 3. Initialize
+### Initialize
 
 ```bash
 vaner init --path .
@@ -65,7 +79,7 @@ your machine. You confirm the client list before anything is written.
 If you want to override the auto-picked bundle, run
 `vaner setup apply <bundle-id>` after init.
 
-## 4. Start
+### Start
 
 ```bash
 vaner up --path .


### PR DESCRIPTION
## Summary
- add a concise interaction-surface matrix to Architecture and Getting Started
- clarify MCP as the agent interface and Desktop/Companion as human controls
- keep CLI under power-user/CI setup and restore the canonical macOS download URL

## Tests
- npm run build
- npm audit --audit-level=moderate
- lychee v0.23.0 against tracked markdown/MDX files