### PR TITLE
docs: clarify Vaner surfaces and Linux install

### DIFF
--- a/content/docs/getting-started.mdx
+++ b/content/docs/getting-started.mdx
@@ -3,9 +3,10 @@ title: Getting Started
 description: Install Vaner Desktop, connect your AI client, and start using Prepared Work.
 ---
 
-The fastest path is the [Vaner Desktop app](https://vaner.ai). It installs the
-engine, picks a local Ollama model that fits your hardware, and wires Vaner
-into the AI clients it detects. No CLI required.
+The fastest path is the [Vaner Desktop app](https://vaner.ai). It gives you the
+human-facing installer, setup, status, and integration controls, picks a local
+Ollama model that fits your hardware, and wires Vaner into the AI clients it
+detects.
 
 macOS, Windows, and Linux are the same Vaner Desktop product. The macOS app
 does not have a separate feature set today; it is a native shell around the
@@ -36,6 +37,20 @@ macOS:
 
 If macOS blocks the first launch for an unsigned 0.x build, right-click
 Vaner and choose **Open** once.
+
+Linux:
+
+1. Download [Vaner for Linux](https://vaner.ai/download/linux-deb).
+2. Install the `.deb`, then launch **Vaner** from your app list.
+
+The Linux desktop package is named `vaner`; the installed GUI command is
+`vaner-desktop`. The power-user CLI remains the PyPI command `vaner`. If Vaner
+ever ships the CLI through apt, that package should be named `vaner-cli`.
+
+Windows:
+
+1. Download [Vaner for Windows](https://vaner.ai/download/windows).
+2. Run the installer, then launch Vaner from the Start menu.
 
 ## Power users / CI
 

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -21,7 +21,7 @@ adopt it.
     href="https://vaner.ai"
     external
     title="Download Vaner Desktop"
-    description="Recommended for everyone on macOS, Windows, and Linux. Starts the engine, picks a local Ollama model that fits your hardware, and wires Vaner into your AI clients."
+    description="Recommended for everyone on macOS, Windows, and Linux. Installs the human-facing Vaner app and wires Vaner into your AI clients."
   />
   <Card
     href="/getting-started"


### PR DESCRIPTION
## Summary
- clarify that Vaner is one local engine with MCP, Desktop, Companion, Cockpit/Web UI, CLI, integration layers, and proxy surfaces
- make Desktop the recommended human install path while moving CLI-first setup under Power users / CI
- add Linux and Windows install links and clarify the Linux package/GUI/CLI names

## Verification
- npm run build
- git diff --check